### PR TITLE
Add missing Storybook story for SubmissionConfirmation

### DIFF
--- a/packages/design/src/Form/PromptSegment/SubmissionConfirmation/SubmissionConfirmation.stories.tsx
+++ b/packages/design/src/Form/PromptSegment/SubmissionConfirmation/SubmissionConfirmation.stories.tsx
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import SubmissionConfirmation, { type SubmissionConfirmationProps } from '.';
+
+export default {
+  title: 'prompts/SubmissionConfirmation',
+  component: SubmissionConfirmation,
+  tags: ['autodocs'],
+} satisfies Meta<typeof SubmissionConfirmation>;
+
+export const SubmissionConfirmationExample = {
+  args: {
+    prompt: {
+      type: 'submission-confirmation',
+      table: [
+        { label: 'Field 1', value: 'Value 1' },
+        { label: 'Field 2', value: 'Value 2' },
+        { label: 'Field 3', value: 'Value 3' },
+        { label: 'Field 4', value: 'Value 4' },
+      ],
+    },
+  } satisfies SubmissionConfirmationProps,
+} satisfies StoryObj<typeof SubmissionConfirmation>;


### PR DESCRIPTION
#48 introduced a bug with Storybook, with a missing story for `SubmissionConfirmation` - this PR adds one.