### PR TITLE
Hardcode the ghcr.io path

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   TAG_NAME: ${{ github.ref_name }}
-  REGISTRY: ghcr.io/${{ github.repository }}
+  REGISTRY: ghcr.io/gsa-tts/atj-platform
 
 jobs:
   init-deploy:
@@ -55,9 +55,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-
-      - name: Lower case registry variable
-        run: REGISTRY=$(echo "$VARIABLE" | tr '[:upper:]' '[:lower:]')
 
       - name: Build container image
         run: docker build . --platform linux/amd64 --target doj-demo --tag ${REGISTRY}/doj-demo:${TAG_NAME}


### PR DESCRIPTION
Hardcode the ghcr.io path, rather than mess with lack of string processing in Github Actions