### PR TITLE
Typescript type checking

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -61,6 +61,13 @@ jobs:
         shell: bash
         run: pnpm test
 
+      - name: Initialize Terraform CDK configuration
+        shell: bash
+        run: |
+          cd infra
+          pnpm cdktf get
+          pnpm build:tsc
+
       - name: Typecheck source code
         shell: bash
         run: pnpm typecheck

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -61,6 +61,10 @@ jobs:
         shell: bash
         run: pnpm test
 
+      - name: Typecheck source code
+        shell: bash
+        run: pnpm typecheck
+
       #- name: Vitest Coverage Report
       #  if: always()
       #  uses: davelosert/vitest-coverage-report-action@v2.2.0

--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,4 @@ html/
 node_modules/
 NOTES.md
 tsconfig.tsbuildinfo
-
 *storybook.log

--- a/apps/cli/tsconfig.json
+++ b/apps/cli/tsconfig.json
@@ -1,12 +1,10 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "CommonJS",
     "outDir": "./dist",
     "emitDeclarationOnly": true
   },
-  "include": [
-    "./src"
-  ],
+  "include": ["./src"],
   "references": []
 }

--- a/apps/doj-demo/tsconfig.json
+++ b/apps/doj-demo/tsconfig.json
@@ -1,16 +1,12 @@
 {
   // For reference, the base Astro tsconfig:
   // https://github.com/withastro/astro/blob/main/packages/astro/tsconfigs/base.json
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "ESNext",
     "jsx": "react",
     "resolveJsonModule": true
   },
-  "include": [
-    "src/**/*.ts"
-  ],
-  "exclude": [
-    "src/components/**"
-  ]
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/components/**"]
 }

--- a/apps/doj-demo/tsconfig.json
+++ b/apps/doj-demo/tsconfig.json
@@ -4,7 +4,6 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "module": "ESNext",
-    "noEmit": true,
     "jsx": "react",
     "resolveJsonModule": true
   },

--- a/apps/rest-api/tsconfig.json
+++ b/apps/rest-api/tsconfig.json
@@ -1,12 +1,10 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
     "emitDeclarationOnly": true,
     "rootDir": "src"
   },
-  "include": [
-    "src/**/*"
-  ],
+  "include": ["src/**/*"],
   "references": []
 }

--- a/apps/rest-api/tsconfig.json
+++ b/apps/rest-api/tsconfig.json
@@ -8,9 +8,5 @@
   "include": [
     "src/**/*"
   ],
-  "references": [
-    {
-      "path": "../../packages/interviews"
-    }
-  ]
+  "references": []
 }

--- a/apps/spotlight/tsconfig.json
+++ b/apps/spotlight/tsconfig.json
@@ -1,16 +1,12 @@
 {
   // For reference, the base Astro tsconfig:
   // https://github.com/withastro/astro/blob/main/packages/astro/tsconfigs/base.json
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "ESNext",
     "jsx": "react",
     "resolveJsonModule": true
   },
-  "include": [
-    "src/**/*.ts"
-  ],
-  "exclude": [
-    "src/components/**"
-  ]
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/components/**"]
 }

--- a/apps/spotlight/tsconfig.json
+++ b/apps/spotlight/tsconfig.json
@@ -4,7 +4,6 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "module": "ESNext",
-    "noEmit": true,
     "jsx": "react",
     "resolveJsonModule": true
   },

--- a/infra/tsconfig.json
+++ b/infra/tsconfig.json
@@ -5,9 +5,7 @@
     "experimentalDecorators": true,
     "inlineSourceMap": true,
     "inlineSources": true,
-    "lib": [
-      "es2018"
-    ],
+    "lib": ["es2018"],
     "module": "CommonJS",
     "noEmitOnError": true,
     "noFallthroughCasesInSwitch": true,
@@ -25,11 +23,6 @@
     "incremental": true,
     "skipLibCheck": true
   },
-  "include": [
-    "**/*.ts"
-  ],
-  "exclude": [
-    "node_modules",
-    "cdktf.out"
-  ]
+  "include": [".gen/**/*.ts", "src/**/*.ts"],
+  "exclude": ["node_modules", "cdktf.out"]
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "pages": "rm -rf node_modules && npm i -g pnpm turbo && pnpm i && pnpm build && ln -sf ./apps/spotlight/dist _site",
     "test": "vitest run --coverage.enabled --coverage.reporter=text --coverage.reporter=json-summary --coverage.reporter=json --coverage.reportOnFailure --reporter vitest-github-actions-reporter",
     "test:infra": "turbo run --filter=infra test",
-    "typecheck": "tsc --build"
+    "typecheck": "tsc --noEmit"
   },
   "hooks": {
     "pre-commit": "pnpm format"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "pages": "rm -rf node_modules && npm i -g pnpm turbo && pnpm i && pnpm build && ln -sf ./apps/spotlight/dist _site",
     "test": "vitest run --coverage.enabled --coverage.reporter=text --coverage.reporter=json-summary --coverage.reporter=json --coverage.reportOnFailure --reporter vitest-github-actions-reporter",
     "test:infra": "turbo run --filter=infra test",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit --jsx preserve --skipLibCheck --incremental --tsBuildInfoFile tsconfig.tsbuildinfo"
   },
   "hooks": {
     "pre-commit": "pnpm format"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "lint": "turbo run lint",
     "pages": "rm -rf node_modules && npm i -g pnpm turbo && pnpm i && pnpm build && ln -sf ./apps/spotlight/dist _site",
     "test": "vitest run --coverage.enabled --coverage.reporter=text --coverage.reporter=json-summary --coverage.reporter=json --coverage.reportOnFailure --reporter vitest-github-actions-reporter",
-    "test:infra": "turbo run --filter=infra test"
+    "test:infra": "turbo run --filter=infra test",
+    "typecheck": "tsc --build"
   },
   "hooks": {
     "pre-commit": "pnpm format"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "pages": "rm -rf node_modules && npm i -g pnpm turbo && pnpm i && pnpm build && ln -sf ./apps/spotlight/dist _site",
     "test": "vitest run --coverage.enabled --coverage.reporter=text --coverage.reporter=json-summary --coverage.reporter=json --coverage.reportOnFailure --reporter vitest-github-actions-reporter",
     "test:infra": "turbo run --filter=infra test",
-    "typecheck": "tsc --noEmit --jsx preserve --skipLibCheck --incremental --tsBuildInfoFile tsconfig.tsbuildinfo"
+    "typecheck": "tsc --build"
   },
   "hooks": {
     "pre-commit": "pnpm format"

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -3,3 +3,6 @@ export type VoidSuccess = { success: true };
 export type Failure<E> = { success: false; error: E };
 export type Result<T, E = string> = Success<T> | Failure<E>;
 export type VoidResult<E = string> = VoidSuccess | Failure<E>;
+
+export const success = <T>(data: T): Success<T> => ({ success: true, data });
+export const failure = <E>(error: E): Failure<E> => ({ success: false, error });

--- a/packages/common/tsconfig.json
+++ b/packages/common/tsconfig.json
@@ -1,11 +1,9 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./dist",
     "emitDeclarationOnly": true
   },
-  "include": [
-    "./src"
-  ],
+  "include": ["./src"],
   "references": []
 }

--- a/packages/dependency-graph/tsconfig.json
+++ b/packages/dependency-graph/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./dist",
     "emitDeclarationOnly": true

--- a/packages/design/src/Form/Form.stories.tsx
+++ b/packages/design/src/Form/Form.stories.tsx
@@ -4,7 +4,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import Form from '.';
 import { createTestFormContext, createTestSession } from '../test-form';
 
-export default {
+const meta: Meta<typeof Form> = {
   title: 'Form',
   component: Form,
   decorators: [(Story, args) => <Story {...args} />],
@@ -13,6 +13,7 @@ export default {
     session: createTestSession(),
   },
   tags: ['autodocs'],
-} satisfies Meta<typeof Form>;
+};
 
+export default meta;
 export const FormTest = {} satisfies StoryObj<typeof Form>;

--- a/packages/design/src/Form/components/FormSummary/FormSummary.stories.tsx
+++ b/packages/design/src/Form/components/FormSummary/FormSummary.stories.tsx
@@ -1,7 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
 import FormSummary from '.';
-import { type FormSummaryProps } from '@atj/forms';
 
 export default {
   title: 'patterns/FormSummary',
@@ -11,13 +10,11 @@ export default {
 
 export const FormSummaryWithLongDescription = {
   args: {
-    pattern: {
-      _patternId: 'test-id',
-      type: 'form-summary',
-      title: 'Form title',
-      description:
-        'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
-    } as FormSummaryProps,
+    _patternId: 'test-id',
+    type: 'form-summary',
+    title: 'Form title',
+    description:
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
   },
 } satisfies StoryObj<typeof FormSummary>;
 

--- a/packages/design/src/Form/components/RadioGroup/RadioGroup.stories.tsx
+++ b/packages/design/src/Form/components/RadioGroup/RadioGroup.stories.tsx
@@ -1,15 +1,16 @@
-import { Meta, Story } from '@storybook/react';
+import { Meta, StoryFn } from '@storybook/react';
 
 import RadioGroup, { RadioInput } from './RadioGroup';
 import React from 'react';
 
-export default {
+const meta: Meta = {
   title: 'Components/RadioGroup',
   component: RadioGroup,
   tags: ['autodocs'],
-} as Meta;
+};
+export default meta;
 
-const Template: Story = () => (
+export const Default: StoryFn = () => (
   <RadioGroup legend="Select an item">
     <RadioInput
       id="option-1"
@@ -31,6 +32,3 @@ const Template: Story = () => (
     />
   </RadioGroup>
 );
-
-export const Default = Template.bind({});
-Default.args = {};

--- a/packages/design/src/Form/components/RadioGroup/RadioGroup.stories.tsx
+++ b/packages/design/src/Form/components/RadioGroup/RadioGroup.stories.tsx
@@ -14,19 +14,19 @@ const Template: Story = () => (
     <RadioInput
       id="option-1"
       name="select-item"
-      defaultValue="option1"
+      defaultChecked={false}
       label="Option 1"
     />
     <RadioInput
       id="option-2"
       name="select-item"
-      defaultValue="option2"
+      defaultChecked={false}
       label="Option 2"
     />
     <RadioInput
       id="option-3"
       name="select-item"
-      defaultValue="option3"
+      defaultChecked={true}
       label="Option 3"
     />
   </RadioGroup>

--- a/packages/design/src/Form/components/RadioGroup/RadioGroup.tsx
+++ b/packages/design/src/Form/components/RadioGroup/RadioGroup.tsx
@@ -1,6 +1,6 @@
 import React, { type ReactElement } from 'react';
 
-type RadioGroupProps = {
+export type RadioGroupProps = {
   legend: string;
   children: ReactElement<RadioProps> | ReactElement<RadioProps>[];
 };

--- a/packages/design/src/Form/components/TextInput/TestInput.stories.tsx
+++ b/packages/design/src/Form/components/TextInput/TestInput.stories.tsx
@@ -4,7 +4,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 
 import TextInput from '.';
 
-export default {
+const meta: Meta<typeof TextInput> = {
   title: 'patterns/TextInput',
   component: TextInput,
   decorators: [
@@ -21,8 +21,9 @@ export default {
     },
   ],
   tags: ['autodocs'],
-} satisfies Meta<typeof TextInput>;
+};
 
+export default meta;
 export const Required = {
   args: {
     _patternId: '',

--- a/packages/design/src/Form/components/TextInput/index.tsx
+++ b/packages/design/src/Form/components/TextInput/index.tsx
@@ -29,7 +29,7 @@ const TextInput: PatternComponent<TextInputProps> = props => {
             id={`input-error-message-${props.inputId}`}
             role="alert"
           >
-            {props.error}
+            {props.error.message}
           </span>
         )}
         <input

--- a/packages/design/src/Form/components/index.tsx
+++ b/packages/design/src/Form/components/index.tsx
@@ -1,4 +1,4 @@
-import { type ComponentForPattern } from '..';
+import { PatternComponent, type ComponentForPattern } from '..';
 
 import Address from './Address';
 import Checkbox from './Checkbox';
@@ -11,13 +11,13 @@ import SubmissionConfirmation from './SubmissionConfirmation';
 import TextInput from './TextInput';
 
 export const defaultPatternComponents: ComponentForPattern = {
-  address: Address,
-  checkbox: Checkbox,
-  fieldset: Fieldset,
-  'form-summary': FormSummary,
-  input: TextInput,
-  paragraph: Paragraph,
-  'radio-group': RadioGroup,
-  sequence: Sequence,
-  'submission-confirmation': SubmissionConfirmation,
+  address: Address as PatternComponent,
+  checkbox: Checkbox as PatternComponent,
+  fieldset: Fieldset as PatternComponent,
+  'form-summary': FormSummary as PatternComponent,
+  input: TextInput as PatternComponent,
+  paragraph: Paragraph as PatternComponent,
+  'radio-group': RadioGroup as PatternComponent,
+  sequence: Sequence as PatternComponent,
+  'submission-confirmation': SubmissionConfirmation as PatternComponent,
 };

--- a/packages/design/src/Form/index.tsx
+++ b/packages/design/src/Form/index.tsx
@@ -77,6 +77,7 @@ export default function Form({
     context.config,
     session
   );
+  console.log('prompt', prompt);
 
   // So the preview view can update the session, regen the prompt.
   // This feels smelly.

--- a/packages/design/src/FormManager/FormDelete/FormDelete.stories.tsx
+++ b/packages/design/src/FormManager/FormDelete/FormDelete.stories.tsx
@@ -7,7 +7,7 @@ import { createTestFormService } from '@atj/form-service';
 import FormDelete from '.';
 import { createTestForm } from '../../test-form';
 
-export default {
+const meta: Meta<typeof FormDelete> = {
   title: 'FormManager/FormDelete',
   component: FormDelete,
   decorators: [
@@ -24,6 +24,7 @@ export default {
     }),
   },
   tags: ['autodocs'],
-} satisfies Meta<typeof FormDelete>;
+};
 
+export default meta;
 export const FormDeleteTest = {} satisfies StoryObj<typeof FormDelete>;

--- a/packages/design/src/FormManager/FormDocumentImport/DocumentImporter/DocumentImporter.stories.tsx
+++ b/packages/design/src/FormManager/FormDocumentImport/DocumentImporter/DocumentImporter.stories.tsx
@@ -5,7 +5,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import DocumentImporter from '.';
 import { createTestForm } from '../../../test-form';
 
-export default {
+const meta: Meta<typeof DocumentImporter> = {
   title: 'FormManager/DocumentImporter',
   component: DocumentImporter,
   decorators: [
@@ -20,6 +20,7 @@ export default {
     form: createTestForm(),
   },
   tags: ['autodocs'],
-} as Meta<typeof DocumentImporter>;
+};
 
+export default meta;
 export const TestForm = {} satisfies StoryObj<typeof DocumentImporter>;

--- a/packages/design/src/FormManager/FormEdit/FormEdit.stories.tsx
+++ b/packages/design/src/FormManager/FormEdit/FormEdit.stories.tsx
@@ -8,7 +8,7 @@ import { FormManagerProvider } from '../store';
 import FormEdit from '.';
 import { createTestForm, createTestFormManagerContext } from '../../test-form';
 
-export default {
+const meta: Meta<typeof FormEdit> = {
   title: 'FormManager/FormEdit',
   component: FormEdit,
   decorators: [
@@ -27,8 +27,9 @@ export default {
     formId: 'test-form',
   },
   tags: ['autodocs'],
-} satisfies Meta<typeof FormEdit>;
+};
 
+export default meta;
 export const FormEditTest: StoryObj<typeof FormEdit> = {
   play: async ({ canvasElement }) => {
     await editFieldLabel(canvasElement, 'Pattern 1', 'Pattern 1 (updated)');

--- a/packages/design/src/FormManager/FormEdit/components/InputPatternEdit.tsx
+++ b/packages/design/src/FormManager/FormEdit/components/InputPatternEdit.tsx
@@ -108,6 +108,7 @@ const EditComponent = ({ patternId }: { patternId: PatternId }) => {
               type="checkbox"
               id={fieldId('required')}
               {...register('required')}
+              defaultChecked={pattern.data.required}
             />
             <label
               style={{ display: 'inline-block' }}

--- a/packages/design/src/FormManager/FormEdit/components/RadioGroupPatternEdit.tsx
+++ b/packages/design/src/FormManager/FormEdit/components/RadioGroupPatternEdit.tsx
@@ -106,24 +106,7 @@ const EditComponent = ({ pattern }: { pattern: RadioGroupPattern }) => {
         </button>
       </div>
       <div className="grid-col-12">
-        <PatternEditActions>
-          <span className="usa-checkbox">
-            <input
-              style={{ display: 'inline-block' }}
-              className="usa-checkbox__input"
-              type="checkbox"
-              id={fieldId('required')}
-              {...register('required')}
-            />
-            <label
-              style={{ display: 'inline-block' }}
-              className="usa-checkbox__label"
-              htmlFor={fieldId('required')}
-            >
-              Required
-            </label>
-          </span>
-        </PatternEditActions>
+        <PatternEditActions />
       </div>
     </div>
   );

--- a/packages/design/src/FormManager/FormEdit/components/common/hooks.ts
+++ b/packages/design/src/FormManager/FormEdit/components/common/hooks.ts
@@ -2,17 +2,11 @@ import { useFormContext } from 'react-hook-form';
 
 import { type Pattern, type PatternId, type PatternMap } from '@atj/forms';
 
-type NestedKeys<T> = T extends object
-  ? {
-      [K in keyof T]-?: K extends string | number
-        ? T[K] extends Array<infer U>
-          ? U extends object
-            ? `${K & string}` | `${K & string}.${NestedKeys<U>}`
-            : `${K & string}`
-          : `${K & string}` | `${K & string}.${NestedKeys<T[K]>}`
-        : never;
-    }[keyof T]
-  : never;
+type NestedKeys<T extends object> = {
+  [K in keyof T & (string | number)]: T[K] extends object
+    ? `${K}` | `${K}.${NestedKeys<T[K]>}`
+    : `${K}`;
+}[keyof T & (string | number)];
 
 export const usePatternEditFormContext = <T extends Pattern>(
   patternId: PatternId

--- a/packages/design/src/FormManager/FormEdit/components/index.ts
+++ b/packages/design/src/FormManager/FormEdit/components/index.ts
@@ -1,4 +1,7 @@
-import { type EditComponentForPattern } from '../types';
+import {
+  type PatternEditComponent,
+  type EditComponentForPattern,
+} from '../types';
 
 import CheckboxPatternEdit from './CheckboxPatternEdit';
 import FieldsetEdit from './FieldsetEdit';
@@ -9,13 +12,13 @@ import RadioGroupPatternEdit from './RadioGroupPatternEdit';
 import SubmissionConfirmationEdit from './SubmissionConfirmationEdit';
 
 export const defaultPatternEditComponents: EditComponentForPattern = {
-  checkbox: CheckboxPatternEdit,
-  paragraph: ParagraphPatternEdit,
-  input: InputPatternEdit,
-  'form-summary': FormSummaryEdit,
-  fieldset: FieldsetEdit,
-  'radio-group': RadioGroupPatternEdit,
-  //sequence: SequencePatternEdit,
-  //sequence: PreviewSequencePattern,
-  'submission-confirmation': SubmissionConfirmationEdit,
+  checkbox: CheckboxPatternEdit as PatternEditComponent,
+  paragraph: ParagraphPatternEdit as PatternEditComponent,
+  input: InputPatternEdit as PatternEditComponent,
+  'form-summary': FormSummaryEdit as PatternEditComponent,
+  fieldset: FieldsetEdit as PatternEditComponent,
+  'radio-group': RadioGroupPatternEdit as PatternEditComponent,
+  //sequence: SequencePatternEdit as PatternEditComponent,
+  //sequence: PreviewSequencePattern as PatternEditComponent,
+  'submission-confirmation': SubmissionConfirmationEdit as PatternEditComponent,
 };

--- a/packages/design/src/FormManager/FormList/CreateNew/PDFFileSelect.stories.tsx
+++ b/packages/design/src/FormManager/FormList/CreateNew/PDFFileSelect.stories.tsx
@@ -9,7 +9,7 @@ import {
 import { FormManagerProvider } from '../../store';
 import CreateNew from '.';
 
-export default {
+const meta: Meta<typeof CreateNew> = {
   title: 'FormManager/FormList/CreateNew',
   component: CreateNew,
   decorators: [
@@ -28,6 +28,7 @@ export default {
     baseUrl: '/',
   },
   tags: ['autodocs'],
-} satisfies Meta<typeof CreateNew>;
+};
 
+export default meta;
 export const CreateNewTest = {} satisfies StoryObj<typeof CreateNew>;

--- a/packages/design/src/FormManager/FormList/CreateNew/file-input.test.ts
+++ b/packages/design/src/FormManager/FormList/CreateNew/file-input.test.ts
@@ -21,7 +21,7 @@ describe('onFileInputChangeGetFile', () => {
         target: {
           files: [new File([], 'file-name.xml')] as unknown as FileList,
         },
-      } as ChangeEvent<HTMLInputPattern>);
+      } as ChangeEvent<HTMLInputElement>);
     });
   });
 });

--- a/packages/design/src/FormManager/FormList/CreateNew/file-input.ts
+++ b/packages/design/src/FormManager/FormList/CreateNew/file-input.ts
@@ -13,7 +13,7 @@ const readFileAsync = (file: File) => {
 
 export const onFileInputChangeGetFile =
   (setFile: ({ name, data }: { name: string; data: Uint8Array }) => void) =>
-  (event: ChangeEvent<HTMLInputPattern>) => {
+  (event: ChangeEvent<HTMLInputElement>) => {
     if (event.target.files && event.target.files.length > 0) {
       const inputFile = event.target.files[0];
       readFileAsync(inputFile).then(data => {

--- a/packages/design/src/FormManager/FormList/FormList.stories.tsx
+++ b/packages/design/src/FormManager/FormList/FormList.stories.tsx
@@ -8,7 +8,7 @@ import FormList from '.';
 import { createTestForm, createTestFormManagerContext } from '../../test-form';
 import { FormManagerProvider } from '../store';
 
-export default {
+const meta: Meta<typeof FormList> = {
   title: 'FormManager/FormList',
   component: FormList,
   decorators: [
@@ -29,6 +29,7 @@ export default {
     }),
   },
   tags: ['autodocs'],
-} as Meta<typeof FormList>;
+};
 
+export default meta;
 export const FormListFilled = {} satisfies StoryObj<typeof FormList>;

--- a/packages/design/src/FormManager/FormManagerLayout/FormManagerLayout.stories.tsx
+++ b/packages/design/src/FormManager/FormManagerLayout/FormManagerLayout.stories.tsx
@@ -7,7 +7,7 @@ import { createTestForm, createTestFormManagerContext } from '../../test-form';
 import { FormManagerProvider } from '../store';
 import { NavPage } from './TopNavigation';
 
-export default {
+const meta: Meta<typeof FormManagerLayout> = {
   title: 'FormManagerLayout',
   component: FormManagerLayout,
   decorators: [
@@ -24,8 +24,9 @@ export default {
   ],
   args: {},
   tags: ['autodocs'],
-} satisfies Meta<typeof FormManagerLayout>;
+};
 
+export default meta;
 export const Configure = {
   args: {
     step: NavPage.configure,

--- a/packages/design/src/FormManager/FormManagerLayout/index.tsx
+++ b/packages/design/src/FormManager/FormManagerLayout/index.tsx
@@ -5,7 +5,7 @@ import { type NavPage, TopNavigation } from './TopNavigation';
 import { BottomNavigation } from './BottomNavigation';
 
 type FormManagerLayoutProps = {
-  children: React.ReactNode;
+  children?: React.ReactNode;
   step?: NavPage;
   back?: string;
   close?: string;

--- a/packages/design/src/FormManager/FormPreview/FormPreview.stories.tsx
+++ b/packages/design/src/FormManager/FormPreview/FormPreview.stories.tsx
@@ -10,7 +10,7 @@ import {
 } from '../../test-form';
 import { FormManagerProvider } from '../store';
 
-export default {
+const meta: Meta<typeof FormPreview> = {
   title: 'FormManager/FormPreview',
   component: FormPreview,
   decorators: [
@@ -30,6 +30,8 @@ export default {
     form: createTestForm(),
   },
   tags: ['autodocs'],
-} satisfies Meta<typeof FormPreview>;
+};
+
+export default meta;
 
 export const FormViewTest = {} satisfies StoryObj<typeof FormPreview>;

--- a/packages/design/src/experiments/document-assembler.tsx
+++ b/packages/design/src/experiments/document-assembler.tsx
@@ -22,7 +22,7 @@ const generatePDF = async () => {
   downloadPdfBytes(pdfBytes);
 };
 
-const previewPDF = async setPreviewPdfUrl => {
+const previewPDF = async (setPreviewPdfUrl: (url: string) => void) => {
   const timestamp = new Date().toISOString();
   const pdfBytes = await generateDummyPDF({ timestamp });
   const pdfBlob = new Blob([pdfBytes], { type: 'application/pdf' });
@@ -30,7 +30,7 @@ const previewPDF = async setPreviewPdfUrl => {
 };
 
 export const DocumentAssembler = () => {
-  const [previewPdfUrl, setPreviewPdfUrl] = useState<URL>();
+  const [previewPdfUrl, setPreviewPdfUrl] = useState<string>();
   return (
     <div>
       <button className="usa-button" onClick={generatePDF}>
@@ -44,7 +44,7 @@ export const DocumentAssembler = () => {
       </button>
       <div>
         {previewPdfUrl ? (
-          <embed src={previewPdfUrl.toString()} width={500} height={600} />
+          <embed src={previewPdfUrl} width={500} height={600} />
         ) : null}
       </div>
     </div>

--- a/packages/design/src/test-helper.ts
+++ b/packages/design/src/test-helper.ts
@@ -1,7 +1,6 @@
 import { ReactElement } from 'react';
 import { describe, test } from 'vitest';
-import { type ReactRenderer, composeStories, Meta } from '@storybook/react';
-import { ComponentAnnotations, type Store_CSFExports } from '@storybook/types';
+import { composeStories } from '@storybook/react';
 import { render } from '@testing-library/react';
 
 type Story = {

--- a/packages/design/src/test-helper.ts
+++ b/packages/design/src/test-helper.ts
@@ -1,7 +1,7 @@
 import { ReactElement } from 'react';
 import { describe, test } from 'vitest';
 import { type ReactRenderer, composeStories, Meta } from '@storybook/react';
-import { type Store_CSFExports } from '@storybook/types';
+import { ComponentAnnotations, type Store_CSFExports } from '@storybook/types';
 import { render } from '@testing-library/react';
 
 type Story = {
@@ -15,12 +15,9 @@ type Story = {
  * @param componentName
  * @param csfExports
  */
-export const describeStories = <
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  TModule extends Store_CSFExports<ReactRenderer, any>,
->(
-  meta: Meta,
-  csfExports: TModule
+export const describeStories = (
+  meta: any, // eslint-disable-line @typescript-eslint/no-explicit-any
+  csfExports: any // eslint-disable-line @typescript-eslint/no-explicit-any
 ) => {
   const composedStories = composeStories(csfExports);
   describe(`Storybook stories: ${meta.title || meta.id}`, () => {

--- a/packages/design/tsconfig.build.json
+++ b/packages/design/tsconfig.build.json
@@ -8,5 +8,6 @@
     "module": "esnext"
   },
   "include": ["./src"],
+  "exclude": ["./src/**/*.stories.*", "**/*.test.*"],
   "references": []
 }

--- a/packages/design/tsconfig.json
+++ b/packages/design/tsconfig.json
@@ -1,14 +1,11 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "baseUrl": "./src",
-    "emitDeclarationOnly": true,
     "jsx": "react",
     "outDir": "./dist",
     "module": "esnext"
   },
-  "include": [
-    "./src"
-  ],
+  "include": ["./src"],
   "references": []
 }

--- a/packages/docassemble/tsconfig.json
+++ b/packages/docassemble/tsconfig.json
@@ -1,12 +1,10 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "ESNext",
     "outDir": "./dist",
     "emitDeclarationOnly": true
   },
-  "include": [
-    "./src"
-  ],
+  "include": ["./src"],
   "references": []
 }

--- a/packages/form-service/tsconfig.json
+++ b/packages/form-service/tsconfig.json
@@ -1,11 +1,9 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./dist",
     "emitDeclarationOnly": true
   },
-  "include": [
-    "./src"
-  ],
+  "include": ["./src"],
   "references": []
 }

--- a/packages/forms/src/components.ts
+++ b/packages/forms/src/components.ts
@@ -1,4 +1,4 @@
-import { getRootPattern } from '..';
+import { type FormError, getRootPattern } from '..';
 import {
   type FormConfig,
   type Pattern,
@@ -13,7 +13,7 @@ export type TextInputProps = PatternProps<{
   value: string;
   label: string;
   required: boolean;
-  error?: string;
+  error?: FormError;
 }>;
 
 export type FormSummaryProps = PatternProps<{

--- a/packages/forms/src/documents/pdf/parsing-api.ts
+++ b/packages/forms/src/documents/pdf/parsing-api.ts
@@ -134,7 +134,6 @@ export const callExternalParser = async (
         id: element.id,
         data: {
           text: element.element_params.text,
-          maxLength: 2048,
         },
       } satisfies ParagraphPattern;
       rootSequence.push(element.id);

--- a/packages/forms/src/pattern.ts
+++ b/packages/forms/src/pattern.ts
@@ -1,5 +1,5 @@
 import { type Result } from '@atj/common';
-import { type FormErrors, type Blueprint, updatePattern } from '..';
+import { type FormErrors, type Blueprint, updatePattern, FormError } from '..';
 
 import { type CreatePrompt } from './components';
 
@@ -18,7 +18,7 @@ export type GetPattern = (form: Blueprint, id: PatternId) => Pattern;
 type ParseUserInput<Pattern, PatternOutput> = (
   pattern: Pattern,
   obj: unknown
-) => Result<PatternOutput, FormErrors>;
+) => Result<PatternOutput, FormError>;
 
 type ParsePatternConfigData<PatternConfigData> = (
   patternData: unknown
@@ -72,7 +72,7 @@ export const validatePattern = (
   patternConfig: PatternConfig,
   pattern: Pattern,
   value: any
-): Result<Pattern['data'], FormErrors> => {
+): Result<Pattern['data'], FormError> => {
   if (!patternConfig.parseUserInput) {
     return {
       success: true,

--- a/packages/forms/src/patterns/address/index.ts
+++ b/packages/forms/src/patterns/address/index.ts
@@ -1,12 +1,8 @@
 import * as z from 'zod';
 
-import {
-  validatePattern,
-  type Pattern,
-  type PatternConfig,
-} from '../../pattern';
+import { type Pattern, type PatternConfig } from '../../pattern';
 import { PatternProps } from '../../components';
-import { safeZodParse } from '../../util/zod';
+import { safeZodParseFormErrors } from '../../util/zod';
 import {
   stateTerritoryOrMilitaryPostAbbreviations,
   stateTerritoryOrMilitaryPostList,
@@ -86,9 +82,9 @@ export const addressConfig: PatternConfig<
     patterns: [],
   },
   parseUserInput: (_, obj) => {
-    return safeZodParse(AddressSchema, obj);
+    return safeZodParseFormErrors(AddressSchema, obj);
   },
-  parseConfigData: obj => safeZodParse(configSchema, obj),
+  parseConfigData: obj => safeZodParseFormErrors(configSchema, obj),
   getChildren(pattern, patterns) {
     return [];
   },

--- a/packages/forms/src/patterns/address/index.ts
+++ b/packages/forms/src/patterns/address/index.ts
@@ -2,7 +2,10 @@ import * as z from 'zod';
 
 import { type Pattern, type PatternConfig } from '../../pattern';
 import { PatternProps } from '../../components';
-import { safeZodParseFormErrors } from '../../util/zod';
+import {
+  safeZodParseFormErrors,
+  safeZodParseToFormError,
+} from '../../util/zod';
 import {
   stateTerritoryOrMilitaryPostAbbreviations,
   stateTerritoryOrMilitaryPostList,
@@ -82,7 +85,7 @@ export const addressConfig: PatternConfig<
     patterns: [],
   },
   parseUserInput: (_, obj) => {
-    return safeZodParseFormErrors(AddressSchema, obj);
+    return safeZodParseToFormError(AddressSchema, obj);
   },
   parseConfigData: obj => safeZodParseFormErrors(configSchema, obj),
   getChildren(pattern, patterns) {

--- a/packages/forms/src/patterns/checkbox.ts
+++ b/packages/forms/src/patterns/checkbox.ts
@@ -3,7 +3,7 @@ import * as z from 'zod';
 import { type Pattern, type PatternConfig, validatePattern } from '../pattern';
 import { type CheckboxProps } from '../components';
 import { getFormSessionValue } from '../session';
-import { safeZodParse } from '../util/zod';
+import { safeZodParseFormErrors } from '../util/zod';
 
 const configSchema = z.object({
   label: z.string().min(1),
@@ -21,10 +21,10 @@ export const checkboxConfig: PatternConfig<CheckboxPattern, PatternOutput> = {
     defaultChecked: false,
   },
   parseUserInput: (_, obj) => {
-    return safeZodParse(PatternOutput, obj);
+    return safeZodParseFormErrors(PatternOutput, obj);
   },
   parseConfigData: obj => {
-    return safeZodParse(configSchema, obj);
+    return safeZodParseFormErrors(configSchema, obj);
   },
   getChildren() {
     return [];

--- a/packages/forms/src/patterns/checkbox.ts
+++ b/packages/forms/src/patterns/checkbox.ts
@@ -3,7 +3,7 @@ import * as z from 'zod';
 import { type Pattern, type PatternConfig, validatePattern } from '../pattern';
 import { type CheckboxProps } from '../components';
 import { getFormSessionValue } from '../session';
-import { safeZodParseFormErrors } from '../util/zod';
+import { safeZodParseFormErrors, safeZodParseToFormError } from '../util/zod';
 
 const configSchema = z.object({
   label: z.string().min(1),
@@ -21,7 +21,7 @@ export const checkboxConfig: PatternConfig<CheckboxPattern, PatternOutput> = {
     defaultChecked: false,
   },
   parseUserInput: (_, obj) => {
-    return safeZodParseFormErrors(PatternOutput, obj);
+    return safeZodParseToFormError(PatternOutput, obj);
   },
   parseConfigData: obj => {
     return safeZodParseFormErrors(configSchema, obj);

--- a/packages/forms/src/patterns/fieldset.ts
+++ b/packages/forms/src/patterns/fieldset.ts
@@ -7,7 +7,7 @@ import {
   getPattern,
 } from '../pattern';
 import { type FieldsetProps, createPromptForPattern } from '../components';
-import { safeZodParse } from '../util/zod';
+import { safeZodParseFormErrors } from '../util/zod';
 
 export type FieldsetPattern = Pattern<{
   legend?: string;
@@ -22,10 +22,10 @@ const configSchema = z.object({
 export const fieldsetConfig: PatternConfig<FieldsetPattern> = {
   displayName: 'Fieldset',
   initial: {
-    legend: "Default Heading",
+    legend: 'Default Heading',
     patterns: [],
   },
-  parseConfigData: obj => safeZodParse(configSchema, obj),
+  parseConfigData: obj => safeZodParseFormErrors(configSchema, obj),
   getChildren(pattern, patterns) {
     return pattern.data.patterns.map(
       (patternId: string) => patterns[patternId]

--- a/packages/forms/src/patterns/form-summary.ts
+++ b/packages/forms/src/patterns/form-summary.ts
@@ -2,7 +2,7 @@ import * as z from 'zod';
 
 import { type Pattern, type PatternConfig } from '../pattern';
 import { type FormSummaryProps } from '../components';
-import { safeZodParse } from '../util/zod';
+import { safeZodParseFormErrors } from '../util/zod';
 
 const configSchema = z.object({
   title: z.string().max(128),
@@ -16,7 +16,7 @@ export const formSummaryConfig: PatternConfig<FormSummary> = {
     title: 'Form title',
     description: 'Form extended description',
   },
-  parseConfigData: obj => safeZodParse(configSchema, obj),
+  parseConfigData: obj => safeZodParseFormErrors(configSchema, obj),
   getChildren() {
     return [];
   },

--- a/packages/forms/src/patterns/input.ts
+++ b/packages/forms/src/patterns/input.ts
@@ -3,7 +3,7 @@ import * as z from 'zod';
 import { type Pattern, type PatternConfig, validatePattern } from '../pattern';
 import { type TextInputProps } from '../components';
 import { getFormSessionValue } from '../session';
-import { safeZodParse } from '../util/zod';
+import { safeZodParseFormErrors } from '../util/zod';
 
 const configSchema = z.object({
   label: z.string().min(1, 'A field label is required'),
@@ -32,9 +32,20 @@ export const inputConfig: PatternConfig<InputPattern, InputPatternOutput> = {
     maxLength: 128,
   },
   parseUserInput: (pattern, obj) => {
-    return safeZodParse(createSchema(pattern['data']), obj);
+    const result = safeZodParseFormErrors(createSchema(pattern['data']), obj);
+    if (result.success) {
+      return {
+        success: true,
+        data: result.data,
+      };
+    } else {
+      return {
+        success: false,
+        error: result.error,
+      };
+    }
   },
-  parseConfigData: obj => safeZodParse(configSchema, obj),
+  parseConfigData: obj => safeZodParseFormErrors(configSchema, obj),
   getChildren() {
     return [];
   },

--- a/packages/forms/src/patterns/input.ts
+++ b/packages/forms/src/patterns/input.ts
@@ -3,7 +3,7 @@ import * as z from 'zod';
 import { type Pattern, type PatternConfig, validatePattern } from '../pattern';
 import { type TextInputProps } from '../components';
 import { getFormSessionValue } from '../session';
-import { safeZodParseFormErrors } from '../util/zod';
+import { safeZodParseFormErrors, safeZodParseToFormError } from '../util/zod';
 
 const configSchema = z.object({
   label: z.string().min(1, 'A field label is required'),
@@ -32,18 +32,7 @@ export const inputConfig: PatternConfig<InputPattern, InputPatternOutput> = {
     maxLength: 128,
   },
   parseUserInput: (pattern, obj) => {
-    const result = safeZodParseFormErrors(createSchema(pattern['data']), obj);
-    if (result.success) {
-      return {
-        success: true,
-        data: result.data,
-      };
-    } else {
-      return {
-        success: false,
-        error: result.error,
-      };
-    }
+    return safeZodParseToFormError(createSchema(pattern['data']), obj);
   },
   parseConfigData: obj => safeZodParseFormErrors(configSchema, obj),
   getChildren() {

--- a/packages/forms/src/patterns/paragraph.ts
+++ b/packages/forms/src/patterns/paragraph.ts
@@ -2,7 +2,7 @@ import * as z from 'zod';
 
 import { type Pattern, type PatternConfig } from '../pattern';
 import { type ParagraphProps } from '../components';
-import { safeZodParse } from '../util/zod';
+import { safeZodParseFormErrors } from '../util/zod';
 
 const configSchema = z.object({
   text: z.string().min(1),
@@ -14,7 +14,7 @@ export const paragraphConfig: PatternConfig<ParagraphPattern> = {
   initial: {
     text: 'Paragraph text...',
   },
-  parseConfigData: obj => safeZodParse(configSchema, obj),
+  parseConfigData: obj => safeZodParseFormErrors(configSchema, obj),
   getChildren() {
     return [];
   },

--- a/packages/forms/src/patterns/radio-group.ts
+++ b/packages/forms/src/patterns/radio-group.ts
@@ -3,6 +3,7 @@ import * as z from 'zod';
 import { Result } from '@atj/common';
 
 import { type RadioGroupProps } from '../components';
+import { type FormError } from '../error';
 import { type Pattern, type PatternConfig, validatePattern } from '../pattern';
 import { getFormSessionValue } from '../session';
 import { safeZodParseFormErrors } from '../util/zod';
@@ -32,22 +33,7 @@ export const radioGroupConfig: PatternConfig<RadioGroupPattern, PatternOutput> =
       ],
     },
     parseUserInput: (pattern, input) => {
-      const result = extractOptionId(pattern.id, input);
-      if (!result.success) {
-        return {
-          success: false,
-          error: {
-            [pattern.id]: {
-              type: 'custom',
-              message: result.error,
-            },
-          },
-        };
-      }
-      return {
-        success: true,
-        data: result.data,
-      };
+      return extractOptionId(pattern.id, input);
     },
     parseConfigData: obj => {
       const result = safeZodParseFormErrors(configSchema, obj);
@@ -99,17 +85,23 @@ const createId = (groupId: string, optionId: string) =>
 export const extractOptionId = (
   groupId: string,
   inputId: unknown
-): Result<string> => {
+): Result<string, FormError> => {
   if (typeof inputId !== 'string') {
     return {
       success: false,
-      error: 'invalid data',
+      error: {
+        type: 'custom',
+        message: 'invalid data',
+      },
     };
   }
   if (!inputId.startsWith(groupId)) {
     return {
       success: false,
-      error: `invalid id: ${inputId}`,
+      error: {
+        type: 'custom',
+        message: `invalid id: ${inputId}`,
+      },
     };
   }
   return {

--- a/packages/forms/src/patterns/radio-group.ts
+++ b/packages/forms/src/patterns/radio-group.ts
@@ -5,7 +5,7 @@ import { Result } from '@atj/common';
 import { type RadioGroupProps } from '../components';
 import { type Pattern, type PatternConfig, validatePattern } from '../pattern';
 import { getFormSessionValue } from '../session';
-import { safeZodParse } from '../util/zod';
+import { safeZodParseFormErrors } from '../util/zod';
 
 const configSchema = z.object({
   label: z.string().min(1),
@@ -50,7 +50,7 @@ export const radioGroupConfig: PatternConfig<RadioGroupPattern, PatternOutput> =
       };
     },
     parseConfigData: obj => {
-      const result = safeZodParse(configSchema, obj);
+      const result = safeZodParseFormErrors(configSchema, obj);
       if (!result.success) {
         console.error(result.error);
       }

--- a/packages/forms/src/patterns/sequence.ts
+++ b/packages/forms/src/patterns/sequence.ts
@@ -7,7 +7,6 @@ import {
   getPattern,
 } from '../pattern';
 import { createPromptForPattern } from '../components';
-import { safeZodParse } from '../util/zod';
 
 export type SequencePattern = Pattern<{
   patterns: PatternId[];
@@ -22,7 +21,7 @@ export const sequenceConfig: PatternConfig<SequencePattern> = {
   initial: {
     patterns: [],
   },
-  parseConfigData: obj => safeZodParse(configSchema, obj),
+  parseConfigData: obj => safeZodParseFormErrors(configSchema, obj),
   getChildren(pattern, patterns) {
     return pattern.data.patterns.map(
       (patternId: string) => patterns[patternId]

--- a/packages/forms/src/patterns/sequence.ts
+++ b/packages/forms/src/patterns/sequence.ts
@@ -7,6 +7,7 @@ import {
   getPattern,
 } from '../pattern';
 import { createPromptForPattern } from '../components';
+import { safeZodParseFormErrors } from '../util/zod';
 
 export type SequencePattern = Pattern<{
   patterns: PatternId[];

--- a/packages/forms/src/response.ts
+++ b/packages/forms/src/response.ts
@@ -6,6 +6,7 @@ import {
   getPattern,
   getPatternConfig,
   validatePattern,
+  FormErrors,
 } from '.';
 import { type PromptAction, createPrompt, isPromptAction } from './components';
 import { type FormSession, updateSession } from './session';
@@ -29,6 +30,7 @@ export const applyPromptResponse = (
     };
   }
   const { errors, values } = parsePromptResponse(session, config, response);
+  console.log('errors', errors);
   const newSession = updateSession(session, values, errors);
 
   return {
@@ -43,7 +45,7 @@ const parsePromptResponse = (
   response: PromptResponse
 ) => {
   const values: Record<string, any> = {};
-  const errors: Record<string, string> = {};
+  const errors: Record<PatternId, FormErrors> = {};
   for (const [patternId, promptValue] of Object.entries(response.data)) {
     const pattern = getPattern(session.form, patternId);
     const patternConfig = getPatternConfig(config, pattern.type);

--- a/packages/forms/src/response.ts
+++ b/packages/forms/src/response.ts
@@ -2,14 +2,12 @@ import { type Result } from '@atj/common';
 
 import {
   type FormConfig,
-  type PatternId,
   getPattern,
   getPatternConfig,
   validatePattern,
-  FormErrors,
 } from '.';
 import { type PromptAction, createPrompt, isPromptAction } from './components';
-import { type FormSession, updateSession } from './session';
+import { type FormSession, updateSession, FormErrorMap } from './session';
 
 export type PromptResponse = {
   action: PromptAction['type'];
@@ -30,7 +28,6 @@ export const applyPromptResponse = (
     };
   }
   const { errors, values } = parsePromptResponse(session, config, response);
-  console.log('errors', errors);
   const newSession = updateSession(session, values, errors);
 
   return {
@@ -45,7 +42,7 @@ const parsePromptResponse = (
   response: PromptResponse
 ) => {
   const values: Record<string, any> = {};
-  const errors: Record<PatternId, FormErrors> = {};
+  const errors: FormErrorMap = {};
   for (const [patternId, promptValue] of Object.entries(response.data)) {
     const pattern = getPattern(session.form, patternId);
     const patternConfig = getPatternConfig(config, pattern.type);

--- a/packages/forms/src/session.ts
+++ b/packages/forms/src/session.ts
@@ -4,6 +4,7 @@ import {
   type Pattern,
   getPatternConfig,
   validatePattern,
+  FormError,
 } from '.';
 import { SequencePattern } from './patterns/sequence';
 import {
@@ -12,11 +13,11 @@ import {
   type PatternValueMap,
 } from './pattern';
 
-type ErrorMap = Record<PatternId, string>;
+export type FormErrorMap = Record<PatternId, FormError>;
 
 export type FormSession = {
   data: {
-    errors: ErrorMap;
+    errors: FormErrorMap;
     values: PatternValueMap;
   };
   form: Blueprint;
@@ -86,7 +87,10 @@ export const updateSessionValue = (
   const pattern = session.form.patterns[id];
   if (pattern.type === 'input') {
     if (pattern && !value) {
-      return addError(nextSession, id, 'Required value not provided.');
+      return addError(nextSession, id, {
+        type: 'required',
+        message: 'Required value not provided.',
+      });
     }
   }
   return nextSession;
@@ -95,7 +99,7 @@ export const updateSessionValue = (
 export const updateSession = (
   session: FormSession,
   values: PatternValueMap,
-  errors: ErrorMap
+  errors: FormErrorMap
 ): FormSession => {
   const keysValid =
     Object.keys(values).every(
@@ -147,7 +151,7 @@ const addValue = <T extends Pattern = Pattern>(
 const addError = (
   session: FormSession,
   id: PatternId,
-  error: string
+  error: FormError
 ): FormSession => ({
   ...session,
   data: {

--- a/packages/forms/src/util/zod.ts
+++ b/packages/forms/src/util/zod.ts
@@ -1,31 +1,38 @@
 import * as z from 'zod';
 
-import { type Result } from '@atj/common';
+import * as r from '@atj/common';
 
 import { type FormErrors, type Pattern } from '..';
 
 export const safeZodParse = <T extends Pattern>(
   schema: z.Schema,
   obj: unknown
-): Result<T['data'], FormErrors> => {
+): r.Result<T['data'], z.ZodError> => {
   const result = schema.safeParse(obj);
   if (result.success) {
-    return {
-      success: true,
-      data: result.data,
-    };
+    return r.success(result.data);
   } else {
-    return {
-      success: false,
-      error: convertZodErrorToFormErrors(result.error),
-    };
+    return r.failure(result.error);
+  }
+};
+
+export const safeZodParseFormErrors = <T extends Pattern>(
+  schema: z.Schema,
+  obj: unknown
+): r.Result<T['data'], FormErrors> => {
+  const result = safeZodParse(schema, obj);
+  if (result.success) {
+    return r.success(result.data);
+  } else {
+    const formErrors = convertZodErrorToFormErrors(result.error);
+    return r.failure(formErrors);
   }
 };
 
 const convertZodErrorToFormErrors = (zodError: z.ZodError): FormErrors => {
   const formErrors: FormErrors = {};
   zodError.errors.forEach(error => {
-    const path = error.path.join('.') || 'root';
+    const path = error.path.join('.');
     if (error.code === 'too_small' && error.minimum === 1) {
       formErrors[path] = {
         type: 'required',

--- a/packages/forms/tsconfig.json
+++ b/packages/forms/tsconfig.json
@@ -1,11 +1,10 @@
 {
-    "extends": "../../tsconfig.json",
-    "compilerOptions": {
-        "outDir": "./dist",
-        "emitDeclarationOnly": true
-    },
-    "include": [
-        "./src"
-    ],
-    "references": []
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "emitDeclarationOnly": true,
+    "outDir": "./dist"
+  },
+  "include": ["./src/**/*"],
+  "exclude": ["./dist"],
+  "references": []
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -161,29 +161,29 @@ importers:
     dependencies:
       '@cdktf/provider-aws':
         specifier: 18.0.1
-        version: 18.0.1(cdktf@0.20.4)(constructs@10.3.0)
+        version: 18.0.1(cdktf@0.20.7)(constructs@10.3.0)
       cdktf:
         specifier: ^0.20.4
-        version: 0.20.4(constructs@10.3.0)
+        version: 0.20.7(constructs@10.3.0)
       cdktf-cli:
         specifier: ^0.20.4
-        version: 0.20.4(ink@3.2.0)(react@17.0.2)
+        version: 0.20.7(ink@3.2.0)(react@17.0.2)
       constructs:
         specifier: ^10.3.0
         version: 10.3.0
     devDependencies:
       '@types/jest':
         specifier: ^29.5.6
-        version: 29.5.6
+        version: 29.5.12
       '@types/node':
         specifier: ^20.8.7
-        version: 20.8.7
+        version: 20.11.16
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@20.8.7)(ts-node@10.9.2)
+        version: 29.7.0(@types/node@20.11.16)(ts-node@10.9.2)
       ts-jest:
         specifier: ^29.1.1
-        version: 29.1.1(@babel/core@7.24.4)(esbuild@0.19.12)(jest@29.7.0)(typescript@5.4.2)
+        version: 29.1.2(@babel/core@7.24.4)(esbuild@0.19.12)(jest@29.7.0)(typescript@5.4.2)
 
   packages/common: {}
 
@@ -283,10 +283,10 @@ importers:
         version: 7.6.17(react-dom@18.2.0)(react@18.2.0)(typescript@5.4.2)(vite@5.2.9)
       '@storybook/test':
         specifier: ^7.6.10
-        version: 7.6.17(jest@29.7.0)
+        version: 7.6.17(jest@29.7.0)(vitest@0.34.6)
       '@storybook/test-runner':
         specifier: ^0.16.0
-        version: 0.16.0
+        version: 0.16.0(@types/node@20.11.16)(ts-node@10.9.2)
       '@storybook/types':
         specifier: ^7.6.10
         version: 7.6.17
@@ -310,7 +310,7 @@ importers:
         version: 7.7.1(eslint@8.56.0)(typescript@5.4.2)
       '@uswds/compile':
         specifier: 1.1.0
-        version: 1.1.0
+        version: 1.1.0(ts-node@10.9.2)
       '@vitejs/plugin-react':
         specifier: ^4.2.1
         version: 4.2.1(vite@5.2.9)
@@ -343,10 +343,10 @@ importers:
         version: 18.2.0(react@18.2.0)
       vite:
         specifier: ^5.2.9
-        version: 5.2.9
+        version: 5.2.9(@types/node@20.11.16)
       vite-plugin-dts:
         specifier: ^3.8.3
-        version: 3.8.3(typescript@5.4.2)(vite@5.2.9)
+        version: 3.8.3(@types/node@20.11.16)(typescript@5.4.2)(vite@5.2.9)
       wait-on:
         specifier: ^7.2.0
         version: 7.2.0
@@ -654,29 +654,6 @@ packages:
     resolution: {integrity: sha512-uU27kfDRlhfKl+w1U6vp16IuvSLtjAxdArVXPa9BvLkrr7CYIsxH5adpHObeAGY/41+syctUWOZ140a2Rvkgjw==}
     engines: {node: '>=6.9.0'}
 
-  /@babel/core@7.23.0:
-    resolution: {integrity: sha512-97z/ju/Jy1rZmDxybphrBuI+jtJjFVoz7Mr9yUQVVVi+DNZE333uFQeMOqcCIy1x3WYBIbWftUSLmbNXNT7qFQ==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@ampproject/remapping': 2.2.1
-      '@babel/code-frame': 7.24.2
-      '@babel/generator': 7.24.4
-      '@babel/helper-compilation-targets': 7.23.6
-      '@babel/helper-module-transforms': 7.23.3(@babel/core@7.23.0)
-      '@babel/helpers': 7.24.4
-      '@babel/parser': 7.24.4
-      '@babel/template': 7.24.0
-      '@babel/traverse': 7.24.1
-      '@babel/types': 7.24.0
-      convert-source-map: 2.0.0
-      debug: 4.3.4
-      gensync: 1.0.0-beta.2
-      json5: 2.2.3
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@babel/core@7.23.7:
     resolution: {integrity: sha512-+UpDgowcmqe36d4NwqvKsyPMlOLNGMsfMmQ5WGCu+siCe3t3dfe9njrzGfdN4qq+bcNUt0+Vw6haRxBOycs4dw==}
     engines: {node: '>=6.9.0'}
@@ -721,16 +698,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@babel/generator@7.23.0:
-    resolution: {integrity: sha512-lN85QRR+5IbYrMWM6Y4pE/noaQtg4pNiqeNGX60eqOfo6gtEj6uw/JagelB8vVztSd7R6M5n1+PQkDbHbBRU4g==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/types': 7.23.6
-      '@jridgewell/gen-mapping': 0.3.3
-      '@jridgewell/trace-mapping': 0.3.18
-      jsesc: 2.5.2
-    dev: true
-
   /@babel/generator@7.23.6:
     resolution: {integrity: sha512-qrSfCYxYQB5owCmGLbl8XRpX1ytXlpueOb0N0UmQwA073KZxejgQTzAmJezxvpwQD9uGtK2shHdi55QT+MbjIw==}
     engines: {node: '>=6.9.0'}
@@ -753,7 +720,7 @@ packages:
     resolution: {integrity: sha512-LvBTxu8bQSQkcyKOU+a1btnNFQ1dMAd0R6PyW3arXes06F6QLWLIrd681bxRPIXlrMGR3XYnW9JyML7dP3qgxg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.23.9
+      '@babel/types': 7.24.0
     dev: false
 
   /@babel/helper-builder-binary-assignment-operator-visitor@7.22.15:
@@ -846,21 +813,7 @@ packages:
     resolution: {integrity: sha512-0pYVBnDKZO2fnSPCrgM/6WMc7eS20Fbok+0r88fp+YtWVLZrp4CkafFGIp+W0VKw4a22sgebPT99y+FDNMdP4w==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.23.6
-
-  /@babel/helper-module-transforms@7.23.3(@babel/core@7.23.0):
-    resolution: {integrity: sha512-7bBs4ED9OmswdfDzpz4MpWgSrV7FXlc3zIagvLFjS5H+Mk7Snr21vQ6QwrsoCGMfNC4e4LQPdoULEt4ykz0SRQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    dependencies:
-      '@babel/core': 7.23.0
-      '@babel/helper-environment-visitor': 7.22.20
-      '@babel/helper-module-imports': 7.22.15
-      '@babel/helper-simple-access': 7.22.5
-      '@babel/helper-split-export-declaration': 7.22.6
-      '@babel/helper-validator-identifier': 7.22.20
-    dev: true
+      '@babel/types': 7.24.0
 
   /@babel/helper-module-transforms@7.23.3(@babel/core@7.23.7):
     resolution: {integrity: sha512-7bBs4ED9OmswdfDzpz4MpWgSrV7FXlc3zIagvLFjS5H+Mk7Snr21vQ6QwrsoCGMfNC4e4LQPdoULEt4ykz0SRQ==}
@@ -927,7 +880,7 @@ packages:
     resolution: {integrity: sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.23.6
+      '@babel/types': 7.24.0
 
   /@babel/helper-skip-transparent-expression-wrappers@7.22.5:
     resolution: {integrity: sha512-tK14r66JZKiC43p8Ki33yLBVJKlQDFoA8GYN67lWCDCqoL6EMMSuM9b+Iff2jHaM/RRFYl7K+iiru7hbRqNx8Q==}
@@ -1057,15 +1010,6 @@ packages:
       '@babel/core': 7.24.4
     dev: false
 
-  /@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.23.0):
-    resolution: {integrity: sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.23.0
-      '@babel/helper-plugin-utils': 7.22.5
-    dev: true
-
   /@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.23.7):
     resolution: {integrity: sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==}
     peerDependencies:
@@ -1082,16 +1026,6 @@ packages:
     dependencies:
       '@babel/core': 7.24.4
       '@babel/helper-plugin-utils': 7.22.5
-    dev: false
-
-  /@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.23.0):
-    resolution: {integrity: sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.23.0
-      '@babel/helper-plugin-utils': 7.22.5
-    dev: true
 
   /@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.23.7):
     resolution: {integrity: sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==}
@@ -1102,12 +1036,12 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.23.0):
-    resolution: {integrity: sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==}
+  /@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.24.4):
+    resolution: {integrity: sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.24.4
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
@@ -1127,7 +1061,6 @@ packages:
     dependencies:
       '@babel/core': 7.24.4
       '@babel/helper-plugin-utils': 7.22.5
-    dev: false
 
   /@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.24.4):
     resolution: {integrity: sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==}
@@ -1187,15 +1120,6 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.23.0):
-    resolution: {integrity: sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.23.0
-      '@babel/helper-plugin-utils': 7.22.5
-    dev: true
-
   /@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.23.7):
     resolution: {integrity: sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==}
     peerDependencies:
@@ -1212,16 +1136,6 @@ packages:
     dependencies:
       '@babel/core': 7.24.4
       '@babel/helper-plugin-utils': 7.22.5
-    dev: false
-
-  /@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.23.0):
-    resolution: {integrity: sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.23.0
-      '@babel/helper-plugin-utils': 7.22.5
-    dev: true
 
   /@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.23.7):
     resolution: {integrity: sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==}
@@ -1239,7 +1153,6 @@ packages:
     dependencies:
       '@babel/core': 7.24.4
       '@babel/helper-plugin-utils': 7.22.5
-    dev: false
 
   /@babel/plugin-syntax-jsx@7.22.5(@babel/core@7.23.7):
     resolution: {integrity: sha512-gvyP4hZrgrs/wWMaocvxZ44Hw0b3W8Pe+cMxc8V1ULQ07oh8VNbIRaoD1LRZVTvD+0nieDKjfgKg89sD7rrKrg==}
@@ -1271,15 +1184,6 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.23.0):
-    resolution: {integrity: sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.23.0
-      '@babel/helper-plugin-utils': 7.22.5
-    dev: true
-
   /@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.23.7):
     resolution: {integrity: sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==}
     peerDependencies:
@@ -1296,16 +1200,6 @@ packages:
     dependencies:
       '@babel/core': 7.24.4
       '@babel/helper-plugin-utils': 7.22.5
-    dev: false
-
-  /@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.23.0):
-    resolution: {integrity: sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.23.0
-      '@babel/helper-plugin-utils': 7.22.5
-    dev: true
 
   /@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.23.7):
     resolution: {integrity: sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==}
@@ -1323,16 +1217,6 @@ packages:
     dependencies:
       '@babel/core': 7.24.4
       '@babel/helper-plugin-utils': 7.22.5
-    dev: false
-
-  /@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.23.0):
-    resolution: {integrity: sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.23.0
-      '@babel/helper-plugin-utils': 7.22.5
-    dev: true
 
   /@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.23.7):
     resolution: {integrity: sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==}
@@ -1350,16 +1234,6 @@ packages:
     dependencies:
       '@babel/core': 7.24.4
       '@babel/helper-plugin-utils': 7.22.5
-    dev: false
-
-  /@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.23.0):
-    resolution: {integrity: sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.23.0
-      '@babel/helper-plugin-utils': 7.22.5
-    dev: true
 
   /@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.23.7):
     resolution: {integrity: sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==}
@@ -1377,16 +1251,6 @@ packages:
     dependencies:
       '@babel/core': 7.24.4
       '@babel/helper-plugin-utils': 7.22.5
-    dev: false
-
-  /@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.23.0):
-    resolution: {integrity: sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.23.0
-      '@babel/helper-plugin-utils': 7.22.5
-    dev: true
 
   /@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.23.7):
     resolution: {integrity: sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==}
@@ -1404,16 +1268,6 @@ packages:
     dependencies:
       '@babel/core': 7.24.4
       '@babel/helper-plugin-utils': 7.22.5
-    dev: false
-
-  /@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.23.0):
-    resolution: {integrity: sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.23.0
-      '@babel/helper-plugin-utils': 7.22.5
-    dev: true
 
   /@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.23.7):
     resolution: {integrity: sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==}
@@ -1431,7 +1285,6 @@ packages:
     dependencies:
       '@babel/core': 7.24.4
       '@babel/helper-plugin-utils': 7.22.5
-    dev: false
 
   /@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.24.4):
     resolution: {integrity: sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==}
@@ -1442,16 +1295,6 @@ packages:
       '@babel/core': 7.24.4
       '@babel/helper-plugin-utils': 7.22.5
     dev: false
-
-  /@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.23.0):
-    resolution: {integrity: sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.23.0
-      '@babel/helper-plugin-utils': 7.22.5
-    dev: true
 
   /@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.23.7):
     resolution: {integrity: sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==}
@@ -1471,7 +1314,6 @@ packages:
     dependencies:
       '@babel/core': 7.24.4
       '@babel/helper-plugin-utils': 7.22.5
-    dev: false
 
   /@babel/plugin-syntax-typescript@7.22.5(@babel/core@7.23.7):
     resolution: {integrity: sha512-1mS2o03i7t1c6VzH6fdQ3OA8tcEIxwG18zIPRp+UY1Ihv6W+XZzBCVxExF9upussPXJ0xE9XRHwMoNs1ep/nRQ==}
@@ -2350,29 +2192,29 @@ packages:
     resolution: {integrity: sha512-W7gp8Q/v1NlCZLsv8pQ3Y0uCu/SHgXOVFK+eUluUKWXmsb6VHkpNx0apdOWWcDbB9sJoKeP8uPrjmehJz6xETQ==}
     dev: true
 
-  /@cdktf/cli-core@0.20.4(react@17.0.2):
-    resolution: {integrity: sha512-x5KqngrqdK7mjocvBiAHPJUEv84djnm2vLOHwSOmTswYBHEP4r+egFFiAb2r2VPUpej4mPtoLNUJfjJ1LVVD1w==}
+  /@cdktf/cli-core@0.20.7(react@17.0.2):
+    resolution: {integrity: sha512-KGTRZ68PHUfiW75GkwOIetp2N9tjIdmTHwmt773jwlNFbi+OMaOEm07XQjtIz2AcuvLpx9u4N0u/uI4T+JfwSg==}
     dependencies:
-      '@cdktf/commons': 0.20.4(constructs@10.1.167)
-      '@cdktf/hcl-tools': 0.20.4
-      '@cdktf/hcl2cdk': 0.20.4(constructs@10.1.167)
-      '@cdktf/hcl2json': 0.20.4
+      '@cdktf/commons': 0.20.7(constructs@10.1.167)
+      '@cdktf/hcl-tools': 0.20.7
+      '@cdktf/hcl2cdk': 0.20.7(constructs@10.1.167)
+      '@cdktf/hcl2json': 0.20.7
       '@cdktf/node-pty-prebuilt-multiarch': 0.10.1-pre.11
-      '@cdktf/provider-schema': 0.20.4(constructs@10.1.167)
-      '@sentry/node': 7.101.1
+      '@cdktf/provider-schema': 0.20.7(constructs@10.1.167)
+      '@sentry/node': 7.110.0
       archiver: 5.3.2
-      cdktf: 0.20.4(constructs@10.1.167)
+      cdktf: 0.20.7(constructs@10.1.167)
       chalk: 4.1.2
       chokidar: 3.6.0
       cli-spinners: 2.9.2
-      codemaker: 1.94.0
+      codemaker: 1.95.0
       constructs: 10.1.167
       cross-fetch: 3.1.8
       cross-spawn: 7.0.3
       detect-port: 1.5.1
       execa: 5.1.1
       extract-zip: 2.0.1
-      follow-redirects: 1.15.5
+      follow-redirects: 1.15.6
       fs-extra: 8.1.0
       https-proxy-agent: 5.0.1
       indent-string: 4.0.0
@@ -2381,8 +2223,8 @@ packages:
       ink-spinner: 4.0.3(ink@3.2.0)(react@17.0.2)
       ink-testing-library: 2.1.0
       ink-use-stdout-dimensions: 1.0.5(ink@3.2.0)(react@17.0.2)
-      jsii: 5.3.19
-      jsii-pacmak: 1.94.0
+      jsii: 5.3.29
+      jsii-pacmak: 1.95.0
       jsii-srcmak: 0.1.1039
       lodash.isequal: 4.5.0
       log4js: 6.9.1
@@ -2412,15 +2254,15 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@cdktf/commons@0.20.4(constructs@10.1.167):
-    resolution: {integrity: sha512-quCT7/Mz1S96YXuv5M2raQ2rTWMkjPyB7OkKe8dMv1CSg3tNry/r//sTMIi/ZrR+jjzz3qW7kDNwouPi7D9L3A==}
+  /@cdktf/commons@0.20.7(constructs@10.1.167):
+    resolution: {integrity: sha512-X1HnLlJjKyOfoWTOIoUbm5cRxWIqKw2gtHs4QgDlTGZm9kc5lW1IbwMuEOv7B1IHFXFFRFwnYg03V56TuoEvqQ==}
     dependencies:
-      '@sentry/node': 7.102.1
-      cdktf: 0.20.4(constructs@10.1.167)
+      '@sentry/node': 7.109.0
+      cdktf: 0.20.7(constructs@10.1.167)
       ci-info: 3.9.0
-      codemaker: 1.94.0
+      codemaker: 1.95.0
       cross-spawn: 7.0.3
-      follow-redirects: 1.15.5
+      follow-redirects: 1.15.6
       fs-extra: 11.2.0
       is-valid-domain: 0.1.6
       log4js: 6.9.1
@@ -2432,28 +2274,28 @@ packages:
       - supports-color
     dev: false
 
-  /@cdktf/hcl-tools@0.20.4:
-    resolution: {integrity: sha512-uZFub433AcKzccdpOTdvcROptOj9vFBY7xuBfItDJUtvQ1/In5fxW4XHdP+A+UOUDgnC3FvN0EDXAF7HjCEqjQ==}
+  /@cdktf/hcl-tools@0.20.7:
+    resolution: {integrity: sha512-B/1/UqoCu9V40oV/qLsBRwqp/Q+0wQOcm7WtgZEKNEvNb+5y01E7UbWLoIvs3k7TX8pzHU9Bl1gACXtHbezpsw==}
     dev: false
 
-  /@cdktf/hcl2cdk@0.20.4(constructs@10.1.167):
-    resolution: {integrity: sha512-XJ0pClv18NtVOJZMIyPC+YZKtyqtswWcO0Ar+4GXBJlOE4ikzr34dvDzI9FoKECOQ/05Q96c9p/DMt3PrTRhVA==}
+  /@cdktf/hcl2cdk@0.20.7(constructs@10.1.167):
+    resolution: {integrity: sha512-xGrVa/SxnLrYM8pSwRfvvAFaj7ak3B3xvuwhj9xTWKZ39f89sX4vPkTuJgoiwIG83iAIlNapUcqMQ0PeqogeBw==}
     dependencies:
-      '@babel/generator': 7.23.6
-      '@babel/template': 7.23.9
-      '@babel/types': 7.23.9
-      '@cdktf/commons': 0.20.4(constructs@10.1.167)
-      '@cdktf/hcl2json': 0.20.4
-      '@cdktf/provider-generator': 0.20.4(constructs@10.1.167)
-      '@cdktf/provider-schema': 0.20.4(constructs@10.1.167)
+      '@babel/generator': 7.24.4
+      '@babel/template': 7.24.0
+      '@babel/types': 7.24.0
+      '@cdktf/commons': 0.20.7(constructs@10.1.167)
+      '@cdktf/hcl2json': 0.20.7
+      '@cdktf/provider-generator': 0.20.7(constructs@10.1.167)
+      '@cdktf/provider-schema': 0.20.7(constructs@10.1.167)
       camelcase: 6.3.0
-      cdktf: 0.20.4(constructs@10.1.167)
-      codemaker: 1.94.0
+      cdktf: 0.20.7(constructs@10.1.167)
+      codemaker: 1.95.0
       deep-equal: 2.2.3
-      glob: 10.3.10
+      glob: 10.3.12
       graphology: 0.25.4(graphology-types@0.24.7)
       graphology-types: 0.24.7
-      jsii-rosetta: 5.3.19
+      jsii-rosetta: 5.3.28
       prettier: 2.8.8
       reserved-words: 0.1.2
       zod: 3.22.4
@@ -2463,8 +2305,8 @@ packages:
       - supports-color
     dev: false
 
-  /@cdktf/hcl2json@0.20.4:
-    resolution: {integrity: sha512-j9rQckF5lm8+9NB6kXqUc/YFKbo5SzZVp96xa2uYe3+1cmjum4SsA3P4M1du6Vuw6GRUh6mtYY6e3JQbZVQ05g==}
+  /@cdktf/hcl2json@0.20.7:
+    resolution: {integrity: sha512-325Swm3ySUEbscSIXrtrNOt0mJCyVTheD5SNuDTcMYLyTPQNgu/6LgKu36YQt0AKK3zUp+f56pEYMitpR9FmLQ==}
     dependencies:
       fs-extra: 11.2.0
     dev: false
@@ -2477,26 +2319,26 @@ packages:
       prebuild-install: 7.1.1
     dev: false
 
-  /@cdktf/provider-aws@18.0.1(cdktf@0.20.4)(constructs@10.3.0):
+  /@cdktf/provider-aws@18.0.1(cdktf@0.20.7)(constructs@10.3.0):
     resolution: {integrity: sha512-gnhfZWlZpzoHwfbC7H/36jSBK3vusGSlNnXsCvEZXKG33EQyR9iv8gbFCEmYAQ4RdyXm3zxKRoVY9c0SkZ7FxA==}
     engines: {node: '>= 18.12.0'}
     peerDependencies:
       cdktf: ^0.19.0
       constructs: ^10.0.0
     dependencies:
-      cdktf: 0.20.4(constructs@10.3.0)
+      cdktf: 0.20.7(constructs@10.3.0)
       constructs: 10.3.0
     dev: false
 
-  /@cdktf/provider-generator@0.20.4(constructs@10.1.167):
-    resolution: {integrity: sha512-pE4Psqlzjf0eV/RTBJvlXx7Q+MmF+7kK98QqR4JPWYofJBl9SRUw2QWas4xxaLXkCzhOio5aHZk4f6YwzT/98w==}
+  /@cdktf/provider-generator@0.20.7(constructs@10.1.167):
+    resolution: {integrity: sha512-O3ZyDp/q73Kg2zn/axA4V62c3QvaGEO44G94eiyi4z6GRokTVQ4eOlkpoqp3spejizhMkA8Lzq+OQ2cvsQygeA==}
     dependencies:
-      '@cdktf/commons': 0.20.4(constructs@10.1.167)
-      '@cdktf/provider-schema': 0.20.4(constructs@10.1.167)
-      '@types/node': 18.19.18
-      codemaker: 1.94.0
+      '@cdktf/commons': 0.20.7(constructs@10.1.167)
+      '@cdktf/provider-schema': 0.20.7(constructs@10.1.167)
+      '@types/node': 18.19.30
+      codemaker: 1.95.0
       fs-extra: 8.1.0
-      glob: 10.3.10
+      glob: 10.3.12
       jsii-srcmak: 0.1.1039
     transitivePeerDependencies:
       - constructs
@@ -2504,11 +2346,11 @@ packages:
       - supports-color
     dev: false
 
-  /@cdktf/provider-schema@0.20.4(constructs@10.1.167):
-    resolution: {integrity: sha512-9PMsdDTRR4n5i/xg++zkoJJ6CjQ62sdhLq5xGapwDBPnOtanUr4iQ/gUvdI+44Fps8Zi7vj7PAR/+k26Hv9w4A==}
+  /@cdktf/provider-schema@0.20.7(constructs@10.1.167):
+    resolution: {integrity: sha512-KVV5YMaMoXgrmT+AsU1y3vCLfyie5/XbSKVVrUnVp5sCrwhsFMl6U59HTDQ52QX3aHWxwTAqEZbljdg6ZUbk9A==}
     dependencies:
-      '@cdktf/commons': 0.20.4(constructs@10.1.167)
-      '@cdktf/hcl2json': 0.20.4
+      '@cdktf/commons': 0.20.7(constructs@10.1.167)
+      '@cdktf/hcl2json': 0.20.7
       deepmerge: 4.3.1
       fs-extra: 11.2.0
     transitivePeerDependencies:
@@ -3284,23 +3126,23 @@ packages:
     resolution: {integrity: sha512-6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw==}
     dev: true
 
-  /@inquirer/checkbox@1.4.0:
-    resolution: {integrity: sha512-7YcekwCvMTjrgjUursrH6AGZUSPw7gKPMvp0VhM3iq9mL46a7AeCfOTQTW0UPeiIfWmZK8wHyAD6wIhfDyLHpw==}
+  /@inquirer/checkbox@1.5.2:
+    resolution: {integrity: sha512-CifrkgQjDkUkWexmgYYNyB5603HhTHI91vLFeQXh6qrTKiCMVASol01Rs1cv6LP/A2WccZSRlJKZhbaBIs/9ZA==}
     engines: {node: '>=14.18.0'}
     dependencies:
-      '@inquirer/core': 5.1.0
-      '@inquirer/type': 1.1.5
+      '@inquirer/core': 6.0.0
+      '@inquirer/type': 1.3.1
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       figures: 3.2.0
     dev: false
 
-  /@inquirer/confirm@2.0.14:
-    resolution: {integrity: sha512-Elzo5VX5lO1q9xy8CChDtDQNVLaucufdZBAM12qdfX1L3NQ+TypnZytGmWDXHBTpBTwuhEuwxNvUw7B0HCURkw==}
+  /@inquirer/confirm@2.0.17:
+    resolution: {integrity: sha512-EqzhGryzmGpy2aJf6LxJVhndxYmFs+m8cxXzf8nejb1DE3sabf6mUgBcp4J0jAUEiAcYzqmkqRr7LPFh/WdnXA==}
     engines: {node: '>=14.18.0'}
     dependencies:
-      '@inquirer/core': 5.1.0
-      '@inquirer/type': 1.1.5
+      '@inquirer/core': 6.0.0
+      '@inquirer/type': 1.3.1
       chalk: 4.1.2
     dev: false
 
@@ -3308,13 +3150,13 @@ packages:
     resolution: {integrity: sha512-faYAYnIfdEuns3jGKykaog5oUqFiEVbCx9nXGZfUhyEEpKcHt5bpJfZTb3eOBQKo8I/v4sJkZeBHmFlSZQuBCw==}
     engines: {node: '>=14.18.0'}
     dependencies:
-      '@inquirer/type': 1.1.5
+      '@inquirer/type': 1.3.1
       '@types/mute-stream': 0.0.1
       '@types/node': 20.11.16
       '@types/wrap-ansi': 3.0.0
       ansi-escapes: 4.3.2
       chalk: 4.1.2
-      cli-spinners: 2.9.1
+      cli-spinners: 2.9.2
       cli-width: 4.1.0
       figures: 3.2.0
       mute-stream: 1.0.0
@@ -3324,17 +3166,17 @@ packages:
       wrap-ansi: 6.2.0
     dev: false
 
-  /@inquirer/core@5.1.0:
-    resolution: {integrity: sha512-EVnific72BhMOMo8mElvrYhGFWJZ73X6j0I+fITIPTsdAz6Z9A3w3csKy+XaH87/5QAEIQHR7RSCVXvQpIqNdQ==}
+  /@inquirer/core@6.0.0:
+    resolution: {integrity: sha512-fKi63Khkisgda3ohnskNf5uZJj+zXOaBvOllHsOkdsXRA/ubQLJQrZchFFi57NKbZzkTunXiBMdvWOv71alonw==}
     engines: {node: '>=14.18.0'}
     dependencies:
-      '@inquirer/type': 1.1.5
-      '@types/mute-stream': 0.0.2
+      '@inquirer/type': 1.3.1
+      '@types/mute-stream': 0.0.4
       '@types/node': 20.11.16
       '@types/wrap-ansi': 3.0.0
       ansi-escapes: 4.3.2
       chalk: 4.1.2
-      cli-spinners: 2.9.1
+      cli-spinners: 2.9.2
       cli-width: 4.1.0
       figures: 3.2.0
       mute-stream: 1.0.0
@@ -3344,41 +3186,41 @@ packages:
       wrap-ansi: 6.2.0
     dev: false
 
-  /@inquirer/editor@1.2.12:
-    resolution: {integrity: sha512-Y7zXQqcglPbbPkx0DPwx6HQFstJR5uex4hoQprjpdxSj8+Bf04+Og6mK/FNxoQbPvoNecegtmMGxDC+hVcMJZA==}
+  /@inquirer/editor@1.2.15:
+    resolution: {integrity: sha512-gQ77Ls09x5vKLVNMH9q/7xvYPT6sIs5f7URksw+a2iJZ0j48tVS6crLqm2ugG33tgXHIwiEqkytY60Zyh5GkJQ==}
     engines: {node: '>=14.18.0'}
     dependencies:
-      '@inquirer/core': 5.1.0
-      '@inquirer/type': 1.1.5
+      '@inquirer/core': 6.0.0
+      '@inquirer/type': 1.3.1
       chalk: 4.1.2
       external-editor: 3.1.0
     dev: false
 
-  /@inquirer/expand@1.1.13:
-    resolution: {integrity: sha512-/+7CGCa7iyJIpli0NtukEAjSI7+wGgjYzsByLVSSAk3U696ZlCCP6iPtsWx6d1qfmaMmCzejcjylOj6OAeu4bA==}
+  /@inquirer/expand@1.1.16:
+    resolution: {integrity: sha512-TGLU9egcuo+s7PxphKUCnJnpCIVY32/EwPCLLuu+gTvYiD8hZgx8Z2niNQD36sa6xcfpdLY6xXDBiL/+g1r2XQ==}
     engines: {node: '>=14.18.0'}
     dependencies:
-      '@inquirer/core': 5.1.0
-      '@inquirer/type': 1.1.5
+      '@inquirer/core': 6.0.0
+      '@inquirer/type': 1.3.1
       chalk: 4.1.2
       figures: 3.2.0
     dev: false
 
-  /@inquirer/input@1.2.13:
-    resolution: {integrity: sha512-gALuvSpZRYfqygPjlYWodMZ4TXwALvw7Pk4tRFhE1oMN79rLVlg88Z/X6JCUh+uV2qLaxxgbeP+cgPWTvuWsCg==}
+  /@inquirer/input@1.2.16:
+    resolution: {integrity: sha512-Ou0LaSWvj1ni+egnyQ+NBtfM1885UwhRCMtsRt2bBO47DoC1dwtCa+ZUNgrxlnCHHF0IXsbQHYtIIjFGAavI4g==}
     engines: {node: '>=14.18.0'}
     dependencies:
-      '@inquirer/core': 5.1.0
-      '@inquirer/type': 1.1.5
+      '@inquirer/core': 6.0.0
+      '@inquirer/type': 1.3.1
       chalk: 4.1.2
     dev: false
 
-  /@inquirer/password@1.1.13:
-    resolution: {integrity: sha512-6STGbL4Vm6ohE2yDBOSENCpCeywnvPux5psZVpvblGDop1oPiZkdsVI+NhsA0c4BE6YT0fNVK8Oqxf5Dgt5k7g==}
+  /@inquirer/password@1.1.16:
+    resolution: {integrity: sha512-aZYZVHLUXZ2gbBot+i+zOJrks1WaiI95lvZCn1sKfcw6MtSSlYC8uDX8sTzQvAsQ8epHoP84UNvAIT0KVGOGqw==}
     engines: {node: '>=14.18.0'}
     dependencies:
-      '@inquirer/input': 1.2.13
-      '@inquirer/type': 1.1.5
+      '@inquirer/core': 6.0.0
+      '@inquirer/type': 1.3.1
       ansi-escapes: 4.3.2
       chalk: 4.1.2
     dev: false
@@ -3387,40 +3229,40 @@ packages:
     resolution: {integrity: sha512-YQeBFzIE+6fcec5N/U2mSz+IcKEG4wtGDwF7MBLIDgITWzB3o723JpKJ1rxWqdCvTXkYE+gDXK/seSN6omo3DQ==}
     engines: {node: '>=14.18.0'}
     dependencies:
-      '@inquirer/checkbox': 1.4.0
-      '@inquirer/confirm': 2.0.14
+      '@inquirer/checkbox': 1.5.2
+      '@inquirer/confirm': 2.0.17
       '@inquirer/core': 2.3.1
-      '@inquirer/editor': 1.2.12
-      '@inquirer/expand': 1.1.13
-      '@inquirer/input': 1.2.13
-      '@inquirer/password': 1.1.13
-      '@inquirer/rawlist': 1.2.13
-      '@inquirer/select': 1.3.0
+      '@inquirer/editor': 1.2.15
+      '@inquirer/expand': 1.1.16
+      '@inquirer/input': 1.2.16
+      '@inquirer/password': 1.1.16
+      '@inquirer/rawlist': 1.2.16
+      '@inquirer/select': 1.3.3
     dev: false
 
-  /@inquirer/rawlist@1.2.13:
-    resolution: {integrity: sha512-f+bASrCY2x2F90MrBYX7nUSetL6FsVLfskhGWEyVwj6VIXzc9T878z3v7KU3V10D1trWrCVHOdeqEcbnO68yhg==}
+  /@inquirer/rawlist@1.2.16:
+    resolution: {integrity: sha512-pZ6TRg2qMwZAOZAV6TvghCtkr53dGnK29GMNQ3vMZXSNguvGqtOVc4j/h1T8kqGJFagjyfBZhUPGwNS55O5qPQ==}
     engines: {node: '>=14.18.0'}
     dependencies:
-      '@inquirer/core': 5.1.0
-      '@inquirer/type': 1.1.5
+      '@inquirer/core': 6.0.0
+      '@inquirer/type': 1.3.1
       chalk: 4.1.2
     dev: false
 
-  /@inquirer/select@1.3.0:
-    resolution: {integrity: sha512-3sL5odCDYI+i+piAFqFa5ULDUKEpc0U1zEY4Wm6gjP6nMAHWM8r1UzMlpQXCyHny91Tz+oeSLeKinAde0z6R7w==}
+  /@inquirer/select@1.3.3:
+    resolution: {integrity: sha512-RzlRISXWqIKEf83FDC9ZtJ3JvuK1l7aGpretf41BCWYrvla2wU8W8MTRNMiPrPJ+1SIqrRC1nZdZ60hD9hRXLg==}
     engines: {node: '>=14.18.0'}
     dependencies:
-      '@inquirer/core': 5.1.0
-      '@inquirer/type': 1.1.5
+      '@inquirer/core': 6.0.0
+      '@inquirer/type': 1.3.1
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       figures: 3.2.0
     dev: false
 
-  /@inquirer/type@1.1.5:
-    resolution: {integrity: sha512-wmwHvHozpPo4IZkkNtbYenem/0wnfI6hvOcGKmPEa0DwuaH5XUQzFqy6OpEpjEegZMhYIk8HDYITI16BPLtrRA==}
-    engines: {node: '>=14.18.0'}
+  /@inquirer/type@1.3.1:
+    resolution: {integrity: sha512-Pe3PFccjPVJV1vtlfVvm9OnlbxqdnP5QcscFEFEnK5quChf1ufZtM0r8mR5ToWHMxZOh0s8o/qp9ANGRTo/DAw==}
+    engines: {node: '>=18'}
     dev: false
 
   /@isaacs/cliui@8.0.2:
@@ -3460,49 +3302,6 @@ packages:
       jest-message-util: 29.7.0
       jest-util: 29.7.0
       slash: 3.0.0
-    dev: true
-
-  /@jest/core@29.7.0:
-    resolution: {integrity: sha512-n7aeXWKMnGtDA48y8TLWJPJmLmmZ642Ceo78cYWEpiD7FzDgmNDV/GCVRorPABdXLJZ/9wzzgZAlHjXjxDHGsg==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    peerDependencies:
-      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
-    peerDependenciesMeta:
-      node-notifier:
-        optional: true
-    dependencies:
-      '@jest/console': 29.7.0
-      '@jest/reporters': 29.7.0
-      '@jest/test-result': 29.7.0
-      '@jest/transform': 29.7.0
-      '@jest/types': 29.6.3
-      '@types/node': 20.11.16
-      ansi-escapes: 4.3.2
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      exit: 0.1.2
-      graceful-fs: 4.2.11
-      jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@20.11.16)
-      jest-haste-map: 29.7.0
-      jest-message-util: 29.7.0
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-resolve-dependencies: 29.7.0
-      jest-runner: 29.7.0
-      jest-runtime: 29.7.0
-      jest-snapshot: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      jest-watcher: 29.7.0
-      micromatch: 4.0.5
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-ansi: 6.0.1
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
     dev: true
 
   /@jest/core@29.7.0(ts-node@10.9.2):
@@ -3620,7 +3419,7 @@ packages:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@jridgewell/trace-mapping': 0.3.18
+      '@jridgewell/trace-mapping': 0.3.25
       '@types/node': 20.11.16
       chalk: 4.1.2
       collect-v8-coverage: 1.0.2
@@ -3683,9 +3482,9 @@ packages:
     resolution: {integrity: sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.24.4
       '@jest/types': 29.6.3
-      '@jridgewell/trace-mapping': 0.3.18
+      '@jridgewell/trace-mapping': 0.3.25
       babel-plugin-istanbul: 6.1.1
       chalk: 4.1.2
       convert-source-map: 2.0.0
@@ -3695,7 +3494,7 @@ packages:
       jest-regex-util: 29.6.3
       jest-util: 29.7.0
       micromatch: 4.0.5
-      pirates: 4.0.5
+      pirates: 4.0.6
       slash: 3.0.0
       write-file-atomic: 4.0.2
     transitivePeerDependencies:
@@ -3739,7 +3538,7 @@ packages:
       magic-string: 0.27.0
       react-docgen-typescript: 2.2.2(typescript@5.4.2)
       typescript: 5.4.2
-      vite: 5.2.9
+      vite: 5.2.9(@types/node@20.11.16)
     dev: true
 
   /@jridgewell/gen-mapping@0.3.3:
@@ -3811,14 +3610,6 @@ packages:
       - supports-color
     dev: true
 
-  /@jsii/check-node@1.94.0:
-    resolution: {integrity: sha512-46W+V1oTFvF9ZpKpPYy//1WUmhZ8AD8O0ElmQtv9mundLHccZm+q7EmCYhozr7rlK5uSjU9/WHfbIx2DwynuJw==}
-    engines: {node: '>= 14.17.0'}
-    dependencies:
-      chalk: 4.1.2
-      semver: 7.6.0
-    dev: false
-
   /@jsii/check-node@1.95.0:
     resolution: {integrity: sha512-E5njkBk6X4WrQHtGeO0ed+cvkMxqinQZY83TJZ9RFEIwrndDfj7asMgWkRkYQRF05AlQXks+Eh8wza7ErIl85Q==}
     engines: {node: '>= 14.17.0'}
@@ -3827,11 +3618,19 @@ packages:
       semver: 7.6.0
     dev: false
 
-  /@jsii/spec@1.95.0:
-    resolution: {integrity: sha512-gQtNQHAvSYIsuOEt/Et256SNFJJhG4mpm4k6bwJ5BX2ibEAN4t0amAKjYslrYLhJo8iSGcMedh/YC9hOReL2Iw==}
+  /@jsii/check-node@1.98.0:
+    resolution: {integrity: sha512-hI53TMW/fylHyY3CrJvqWvfSPJvBL82GSAB1m2CKNC0yHb0pZHCdBZnLrrr4rgTCQx8kIJjcUc0rQ/Ba3w+GaA==}
     engines: {node: '>= 14.17.0'}
     dependencies:
-      ajv: 8.12.0
+      chalk: 4.1.2
+      semver: 7.6.0
+    dev: false
+
+  /@jsii/spec@1.98.0:
+    resolution: {integrity: sha512-5FCJedjFrxKt0wrcSnXetHHTXQV6OQM2NlE/WJNvjwqlk+RYfw+BwZOBYHsoaQx1Qh0pTwN7ZM9WmEusN3GdNw==}
+    engines: {node: '>= 14.17.0'}
+    dependencies:
+      ajv: 8.13.0
     dev: false
 
   /@juggle/resize-observer@3.4.0:
@@ -3852,27 +3651,27 @@ packages:
     resolution: {integrity: sha512-ojkXjR3K0Zz3jnCR80tqPL+0yvbZk/lEodb6RIVjLz7W8RVA2wrw8ym/CzCpXO9SYVUIKHFUpc7jvf8UKfIM3w==}
     dev: false
 
-  /@microsoft/api-extractor-model@7.28.13:
+  /@microsoft/api-extractor-model@7.28.13(@types/node@20.11.16):
     resolution: {integrity: sha512-39v/JyldX4MS9uzHcdfmjjfS6cYGAoXV+io8B5a338pkHiSt+gy2eXQ0Q7cGFJ7quSa1VqqlMdlPrB6sLR/cAw==}
     dependencies:
       '@microsoft/tsdoc': 0.14.2
       '@microsoft/tsdoc-config': 0.16.2
-      '@rushstack/node-core-library': 4.0.2
+      '@rushstack/node-core-library': 4.0.2(@types/node@20.11.16)
     transitivePeerDependencies:
       - '@types/node'
     dev: true
 
-  /@microsoft/api-extractor@7.43.0:
+  /@microsoft/api-extractor@7.43.0(@types/node@20.11.16):
     resolution: {integrity: sha512-GFhTcJpB+MI6FhvXEI9b2K0snulNLWHqC/BbcJtyNYcKUiw7l3Lgis5ApsYncJ0leALX7/of4XfmXk+maT111w==}
     hasBin: true
     dependencies:
-      '@microsoft/api-extractor-model': 7.28.13
+      '@microsoft/api-extractor-model': 7.28.13(@types/node@20.11.16)
       '@microsoft/tsdoc': 0.14.2
       '@microsoft/tsdoc-config': 0.16.2
-      '@rushstack/node-core-library': 4.0.2
+      '@rushstack/node-core-library': 4.0.2(@types/node@20.11.16)
       '@rushstack/rig-package': 0.5.2
-      '@rushstack/terminal': 0.10.0
-      '@rushstack/ts-command-line': 4.19.1
+      '@rushstack/terminal': 0.10.0(@types/node@20.11.16)
+      '@rushstack/ts-command-line': 4.19.1(@types/node@20.11.16)
       lodash: 4.17.21
       minimatch: 3.0.8
       resolve: 1.22.8
@@ -5062,7 +4861,7 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@rushstack/node-core-library@4.0.2:
+  /@rushstack/node-core-library@4.0.2(@types/node@20.11.16):
     resolution: {integrity: sha512-hyES82QVpkfQMeBMteQUnrhASL/KHPhd7iJ8euduwNJG4mu2GSOKybf0rOEjOm1Wz7CwJEUm9y0yD7jg2C1bfg==}
     peerDependencies:
       '@types/node': '*'
@@ -5070,6 +4869,7 @@ packages:
       '@types/node':
         optional: true
     dependencies:
+      '@types/node': 20.11.16
       fs-extra: 7.0.1
       import-lazy: 4.0.0
       jju: 1.4.0
@@ -5085,7 +4885,7 @@ packages:
       strip-json-comments: 3.1.1
     dev: true
 
-  /@rushstack/terminal@0.10.0:
+  /@rushstack/terminal@0.10.0(@types/node@20.11.16):
     resolution: {integrity: sha512-UbELbXnUdc7EKwfH2sb8ChqNgapUOdqcCIdQP4NGxBpTZV2sQyeekuK3zmfQSa/MN+/7b4kBogl2wq0vpkpYGw==}
     peerDependencies:
       '@types/node': '*'
@@ -5093,14 +4893,15 @@ packages:
       '@types/node':
         optional: true
     dependencies:
-      '@rushstack/node-core-library': 4.0.2
+      '@rushstack/node-core-library': 4.0.2(@types/node@20.11.16)
+      '@types/node': 20.11.16
       supports-color: 8.1.1
     dev: true
 
-  /@rushstack/ts-command-line@4.19.1:
+  /@rushstack/ts-command-line@4.19.1(@types/node@20.11.16):
     resolution: {integrity: sha512-J7H768dgcpG60d7skZ5uSSwyCZs/S2HrWP1Ds8d1qYAyaaeJmpmmLr9BVw97RjFzmQPOYnoXcKA4GkqDCkduQg==}
     dependencies:
-      '@rushstack/terminal': 0.10.0
+      '@rushstack/terminal': 0.10.0(@types/node@20.11.16)
       '@types/argparse': 1.0.38
       argparse: 1.0.10
       string-argv: 0.3.2
@@ -5108,82 +4909,82 @@ packages:
       - '@types/node'
     dev: true
 
-  /@sentry-internal/tracing@7.101.1:
-    resolution: {integrity: sha512-ihjWG8x4x0ozx6t+EHoXLKbsPrgzYLCpeBLWyS+M6n3hn6cmHM76c8nZw3ldhUQi5UYL3LFC/JZ50b4oSxtlrg==}
+  /@sentry-internal/tracing@7.109.0:
+    resolution: {integrity: sha512-PzK/joC5tCuh2R/PRh+7dp+uuZl7pTsBIjPhVZHMTtb9+ls65WkdZJ1/uKXPouyz8NOo9Xok7aEvEo9seongyw==}
     engines: {node: '>=8'}
     dependencies:
-      '@sentry/core': 7.101.1
-      '@sentry/types': 7.101.1
-      '@sentry/utils': 7.101.1
+      '@sentry/core': 7.109.0
+      '@sentry/types': 7.109.0
+      '@sentry/utils': 7.109.0
     dev: false
 
-  /@sentry-internal/tracing@7.102.1:
-    resolution: {integrity: sha512-RkFlFyAC0fQOvBbBqnq0CLmFW5m3JJz9pKbZd5vXPraWAlniKSb1bC/4DF9SlNx0FN1LWG+IU3ISdpzwwTeAGg==}
+  /@sentry-internal/tracing@7.110.0:
+    resolution: {integrity: sha512-IIHHa9e/mE7uOMJfNELI8adyoELxOy6u6TNCn5t6fphmq84w8FTc9adXkG/FY2AQpglkIvlILojfMROFB2aaAQ==}
     engines: {node: '>=8'}
     dependencies:
-      '@sentry/core': 7.102.1
-      '@sentry/types': 7.102.1
-      '@sentry/utils': 7.102.1
+      '@sentry/core': 7.110.0
+      '@sentry/types': 7.110.0
+      '@sentry/utils': 7.110.0
     dev: false
 
-  /@sentry/core@7.101.1:
-    resolution: {integrity: sha512-XSmXXeYT1d4O14eDF3OXPJFUgaN2qYEeIGUztqPX9nBs9/ij8y/kZOayFqlIMnfGvjOUM+63sy/2xDBOpFn6ug==}
+  /@sentry/core@7.109.0:
+    resolution: {integrity: sha512-xwD4U0IlvvlE/x/g/W1I8b4Cfb16SsCMmiEuBf6XxvAa3OfWBxKoqLifb3GyrbxMC4LbIIZCN/SvLlnGJPgszA==}
     engines: {node: '>=8'}
     dependencies:
-      '@sentry/types': 7.101.1
-      '@sentry/utils': 7.101.1
+      '@sentry/types': 7.109.0
+      '@sentry/utils': 7.109.0
     dev: false
 
-  /@sentry/core@7.102.1:
-    resolution: {integrity: sha512-QjY+LSP3du3J/C8x/FfEbRxgZgsWd0jfTJ4P7s9f219I1csK4OeBMC3UA1HwEa0pY/9OF6H/egW2CjOcMM5Pdg==}
+  /@sentry/core@7.110.0:
+    resolution: {integrity: sha512-g4suCQO94mZsKVaAbyD1zLFC5YSuBQCIPHXx9fdgtfoPib7BWjWWePkllkrvsKAv4u8Oq05RfnKOhOMRHpOKqg==}
     engines: {node: '>=8'}
     dependencies:
-      '@sentry/types': 7.102.1
-      '@sentry/utils': 7.102.1
+      '@sentry/types': 7.110.0
+      '@sentry/utils': 7.110.0
     dev: false
 
-  /@sentry/node@7.101.1:
-    resolution: {integrity: sha512-iXSxUT6Zbt/KUY0+fRcW5II6Tgp2zdTfhBW+fQuDt/UUZt7Ypvb+6n4U2oom3LJfttmD7mdjQuT4+vsNImDjTQ==}
+  /@sentry/node@7.109.0:
+    resolution: {integrity: sha512-tqMNAES4X/iBl1eZRCmc29p//0id01FBLEiesNo5nk6ECl6/SaGMFAEwu1gsn90h/Bjgr04slwFOS4cR45V2PQ==}
     engines: {node: '>=8'}
     dependencies:
-      '@sentry-internal/tracing': 7.101.1
-      '@sentry/core': 7.101.1
-      '@sentry/types': 7.101.1
-      '@sentry/utils': 7.101.1
+      '@sentry-internal/tracing': 7.109.0
+      '@sentry/core': 7.109.0
+      '@sentry/types': 7.109.0
+      '@sentry/utils': 7.109.0
     dev: false
 
-  /@sentry/node@7.102.1:
-    resolution: {integrity: sha512-mb3vmM3SGuCruckPiv/Vafeh89UQavTfpPFoU6Jwe6dSpQ39BO8fO8k8Zev+/nP6r/FKLtX17mJobErHECXsYw==}
+  /@sentry/node@7.110.0:
+    resolution: {integrity: sha512-YPfweCSzo/omnx5q1xOEZfI8Em3jnPqj7OM4ObXmoSKEK+kM1oUF3BTRzw5BJOaOCSTBFY1RAsGyfVIyrwxWnA==}
     engines: {node: '>=8'}
     dependencies:
-      '@sentry-internal/tracing': 7.102.1
-      '@sentry/core': 7.102.1
-      '@sentry/types': 7.102.1
-      '@sentry/utils': 7.102.1
+      '@sentry-internal/tracing': 7.110.0
+      '@sentry/core': 7.110.0
+      '@sentry/types': 7.110.0
+      '@sentry/utils': 7.110.0
     dev: false
 
-  /@sentry/types@7.101.1:
-    resolution: {integrity: sha512-bwtkQvrCZ6JGc7vqX7TEAKBgkbQFORt84FFS3JQQb8G3efTt9fZd2ReY4buteKQdlALl8h1QWVngTLmI+kyUuw==}
+  /@sentry/types@7.109.0:
+    resolution: {integrity: sha512-egCBnDv3YpVFoNzRLdP0soVrxVLCQ+rovREKJ1sw3rA2/MFH9WJ+DZZexsX89yeAFzy1IFsCp7/dEqudusml6g==}
     engines: {node: '>=8'}
     dev: false
 
-  /@sentry/types@7.102.1:
-    resolution: {integrity: sha512-htKorf3t/D0XYtM7foTcmG+rM47rDP6XdbvCcX5gBCuCYlzpM1vqCt2rl3FLktZC6TaIpFRJw1TLfx6m+x5jdA==}
+  /@sentry/types@7.110.0:
+    resolution: {integrity: sha512-DqYBLyE8thC5P5MuPn+sj8tL60nCd/f5cerFFPcudn5nJ4Zs1eI6lKlwwyHYTEu5c4KFjCB0qql6kXfwAHmTyA==}
     engines: {node: '>=8'}
     dev: false
 
-  /@sentry/utils@7.101.1:
-    resolution: {integrity: sha512-Nrg0nrEI3nrOCd9SLJ/WGzxS5KMQE4cryLOvrDcHJRWpsSyGBF1hLLerk84Nsw/0myMsn7zTYU+xoq7idNsX5A==}
-    engines: {node: '>=8'}
-    dependencies:
-      '@sentry/types': 7.101.1
-    dev: false
-
-  /@sentry/utils@7.102.1:
-    resolution: {integrity: sha512-+8WcFjHVV/HROXSAwMuUzveElBFC43EiTG7SNEBNgOUeQzQVTmbUZXyTVgLrUmtoWqvnIxCacoLxtZo1o67kdg==}
+  /@sentry/utils@7.109.0:
+    resolution: {integrity: sha512-3RjxMOLMBwZ5VSiH84+o/3NY2An4Zldjz0EbfEQNRY9yffRiCPJSQiCJID8EoylCFOh/PAhPimBhqbtWJxX6iw==}
     engines: {node: '>=8'}
     dependencies:
-      '@sentry/types': 7.102.1
+      '@sentry/types': 7.109.0
+    dev: false
+
+  /@sentry/utils@7.110.0:
+    resolution: {integrity: sha512-VBsdLLN+5tf73fhf/Cm7JIsUJ6y9DkJj8h4I6Mxx0rszrvOyH6S5px40K+V4jdLBzMEvVinC7q2Cbf1YM18BSw==}
+    engines: {node: '>=8'}
+    dependencies:
+      '@sentry/types': 7.110.0
     dev: false
 
   /@sideway/address@4.1.4:
@@ -5484,7 +5285,7 @@ packages:
       magic-string: 0.30.9
       rollup: 3.29.4
       typescript: 5.4.2
-      vite: 5.2.9
+      vite: 5.2.9(@types/node@20.11.16)
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -5842,7 +5643,7 @@ packages:
       react: 18.2.0
       react-docgen: 7.0.3
       react-dom: 18.2.0(react@18.2.0)
-      vite: 5.2.9
+      vite: 5.2.9(@types/node@20.11.16)
     transitivePeerDependencies:
       - '@preact/preset-vite'
       - encoding
@@ -5916,7 +5717,7 @@ packages:
       - supports-color
     dev: false
 
-  /@storybook/test-runner@0.16.0:
+  /@storybook/test-runner@0.16.0(@types/node@20.11.16)(ts-node@10.9.2):
     resolution: {integrity: sha512-LDmNbKFoEDW/VS9o6KR8e1r5MnbCc5ZojUfi5yqLdq80gFD7BvilgKgV0lUh/xWHryzoy+Ids5LYgrPJZmU2dQ==}
     engines: {node: ^16.10.0 || ^18.0.0 || >=20.0.0}
     hasBin: true
@@ -5936,7 +5737,7 @@ packages:
       commander: 9.5.0
       expect-playwright: 0.8.0
       glob: 10.3.12
-      jest: 29.7.0
+      jest: 29.7.0(@types/node@20.11.16)(ts-node@10.9.2)
       jest-circus: 29.7.0
       jest-environment-node: 29.7.0
       jest-junit: 16.0.0
@@ -5960,7 +5761,7 @@ packages:
       - ts-node
     dev: true
 
-  /@storybook/test@7.6.17(jest@29.7.0):
+  /@storybook/test@7.6.17(jest@29.7.0)(vitest@0.34.6):
     resolution: {integrity: sha512-WGrmUUtKiuq3bzDsN4MUvluGcX120jwczMik1GDTyxS+JBoe7P0t2Y8dDuVs/l3nZd1J7qY4z0RGxMDYqONIOw==}
     dependencies:
       '@storybook/client-logger': 7.6.17
@@ -5968,7 +5769,7 @@ packages:
       '@storybook/instrumenter': 7.6.17
       '@storybook/preview-api': 7.6.17
       '@testing-library/dom': 9.3.4
-      '@testing-library/jest-dom': 6.4.2(jest@29.7.0)
+      '@testing-library/jest-dom': 6.4.2(jest@29.7.0)(vitest@0.34.6)
       '@testing-library/user-event': 14.3.0(@testing-library/dom@9.3.4)
       '@types/chai': 4.3.5
       '@vitest/expect': 0.34.6
@@ -6167,7 +5968,7 @@ packages:
       pretty-format: 27.5.1
     dev: true
 
-  /@testing-library/jest-dom@6.4.2(jest@29.7.0):
+  /@testing-library/jest-dom@6.4.2(jest@29.7.0)(vitest@0.34.6):
     resolution: {integrity: sha512-CzqH0AFymEMG48CpzXFriYYkOjk6ZGPCLMhW9e9jg3KMCn5OfJecF8GtGW7yGfR/IgCe3SX8BSwjdzI6BBbZLw==}
     engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
     peerDependencies:
@@ -6194,9 +5995,10 @@ packages:
       chalk: 3.0.0
       css.escape: 1.5.1
       dom-accessibility-api: 0.6.3
-      jest: 29.7.0
+      jest: 29.7.0(@types/node@20.11.16)(ts-node@10.9.2)
       lodash: 4.17.21
       redent: 3.0.0
+      vitest: 0.34.6(@vitest/ui@1.2.2)
     dev: true
 
   /@testing-library/react@15.0.2(react-dom@18.2.0)(react@18.2.0):
@@ -6262,18 +6064,18 @@ packages:
   /@types/babel__generator@7.6.5:
     resolution: {integrity: sha512-h9yIuWbJKdOPLJTbmSpPzkF67e659PbQDba7ifWm5BJ8xTv+sDmS7rFmywkWOvXedGTivCdeGSIIX8WLcRTz8w==}
     dependencies:
-      '@babel/types': 7.23.6
+      '@babel/types': 7.24.0
 
   /@types/babel__template@7.4.2:
     resolution: {integrity: sha512-/AVzPICMhMOMYoSx9MoKpGDKdBRsIXMNByh1PXSZoa+v6ZoLa8xxtsT/uLQ/NJm0XVAWl/BvId4MlDeXJaeIZQ==}
     dependencies:
       '@babel/parser': 7.23.6
-      '@babel/types': 7.23.6
+      '@babel/types': 7.24.0
 
   /@types/babel__traverse@7.20.2:
     resolution: {integrity: sha512-ojlGK1Hsfce93J0+kn3H5R73elidKUaZonirN33GSmgTUMpzI/MIFfSpF3haANe3G1bEBS9/9/QEqwTzwqFsKw==}
     dependencies:
-      '@babel/types': 7.23.6
+      '@babel/types': 7.24.0
 
   /@types/body-parser@1.19.5:
     resolution: {integrity: sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==}
@@ -6410,8 +6212,8 @@ packages:
       '@types/istanbul-lib-report': 3.0.1
     dev: true
 
-  /@types/jest@29.5.6:
-    resolution: {integrity: sha512-/t9NnzkOpXb4Nfvg17ieHE6EeSjDS2SGSpNYfoLbUAeL/EOueU/RSdOWFpfQTXBEM7BguYW1XQ0EbM+6RlIh6w==}
+  /@types/jest@29.5.12:
+    resolution: {integrity: sha512-eDC8bTvT/QhYdxJAulQikueigY5AsdBRH2yDKW3yveW7svY3+DzN84/2NUgkw10RTiJbWqZrTtoGVdYlvFJdLw==}
     dependencies:
       expect: 29.7.0
       pretty-format: 29.7.0
@@ -6459,8 +6261,8 @@ packages:
       '@types/node': 20.11.16
     dev: false
 
-  /@types/mute-stream@0.0.2:
-    resolution: {integrity: sha512-FpiGjk6+IOrN0lZEfUUjdra1csU1VxwYFj4S0Zj+TJpu5x5mZW30RkEZojTadrNZHNmpCHgoE62IQZAH0OeuIA==}
+  /@types/mute-stream@0.0.4:
+    resolution: {integrity: sha512-CPM9nzrCPPJHQNA9keH9CVkVI+WR5kMa+7XEs5jcGQ0VoAGnLv242w8lIVgwAEfmE4oufJRaTc9PNLQl0ioAow==}
     dependencies:
       '@types/node': 20.11.16
     dev: false
@@ -6482,16 +6284,16 @@ packages:
     dependencies:
       undici-types: 5.26.5
 
+  /@types/node@18.19.30:
+    resolution: {integrity: sha512-453z1zPuJLVDbyahaa1sSD5C2sht6ZpHp5rgJNs+H8YGqhluCXcuOUmBYsAo0Tos0cHySJ3lVUGbGgLlqIkpyg==}
+    dependencies:
+      undici-types: 5.26.5
+    dev: false
+
   /@types/node@20.11.16:
     resolution: {integrity: sha512-gKb0enTmRCzXSSUJDq6/sPcqrfCv2mkkG6Jt/clpn5eiCbKTY+SgZUxo+p8ZKMof5dCp9vHQUAB7wOUTod22wQ==}
     dependencies:
       undici-types: 5.26.5
-
-  /@types/node@20.8.7:
-    resolution: {integrity: sha512-21TKHHh3eUHIi2MloeptJWALuCu5H7HQTdTrWIFReA8ad+aggoX+lRes3ex7/FtpC+sVUpFMQ+QTfYr74mruiQ==}
-    dependencies:
-      undici-types: 5.25.3
-    dev: true
 
   /@types/normalize-package-data@2.4.4:
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
@@ -6613,8 +6415,8 @@ packages:
       '@types/yargs-parser': 21.0.1
     dev: true
 
-  /@types/yauzl@2.10.1:
-    resolution: {integrity: sha512-CHzgNU3qYBnp/O4S3yv2tXPlvMTq0YWSTVg2/JYLqWZGHwwgJGAwd00poay/11asPq8wLFwHzubyInqHIFmmiw==}
+  /@types/yauzl@2.10.3:
+    resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
     requiresBuild: true
     dependencies:
       '@types/node': 20.11.16
@@ -6760,13 +6562,13 @@ packages:
   /@ungap/structured-clone@1.2.0:
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
 
-  /@uswds/compile@1.1.0:
+  /@uswds/compile@1.1.0(ts-node@10.9.2):
     resolution: {integrity: sha512-kKlszBhO13v/qa1jaNqaOWiAJjuKtASHCxjmu+OXw/wMGVdaJcNjkM8hWL9/sx4AUe07PBwlJoGPtkKRWqSxWw==}
     dependencies:
       autoprefixer: 10.4.16(postcss@8.4.31)
       del: 6.1.1
       gulp: 4.0.2
-      gulp-postcss: 9.0.1(postcss@8.4.31)
+      gulp-postcss: 9.0.1(postcss@8.4.31)(ts-node@10.9.2)
       gulp-rename: 2.0.0
       gulp-replace: 1.1.4
       gulp-sass: 5.1.0
@@ -6801,7 +6603,7 @@ packages:
       '@babel/plugin-transform-react-jsx-source': 7.23.3(@babel/core@7.24.4)
       magic-string: 0.27.0
       react-refresh: 0.14.0
-      vite: 5.2.9
+      vite: 5.2.9(@types/node@20.11.16)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -6817,7 +6619,7 @@ packages:
       '@babel/plugin-transform-react-jsx-source': 7.23.3(@babel/core@7.23.7)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.0
-      vite: 5.2.9
+      vite: 5.2.9(@types/node@20.11.16)
     transitivePeerDependencies:
       - supports-color
 
@@ -7264,8 +7066,8 @@ packages:
       uri-js: 4.4.1
     dev: true
 
-  /ajv@8.12.0:
-    resolution: {integrity: sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==}
+  /ajv@8.13.0:
+    resolution: {integrity: sha512-PRA911Blj99jR5RMeTunVbNXMF6Lp4vZXnk5GQjcnUWUTsrXtekg/pnmFFI2u/I36Y/2bITGS30GZCXei6uNkA==}
     dependencies:
       fast-deep-equal: 3.1.3
       json-schema-traverse: 1.0.0
@@ -7431,18 +7233,6 @@ packages:
       readable-stream: 3.6.2
     dev: false
 
-  /archiver-utils@4.0.1:
-    resolution: {integrity: sha512-Q4Q99idbvzmgCTEAAhi32BkOyq8iVI5EwdO0PmBDSGIzzjYNdcFn7Q7k3OzbLy4kLUPXfJtG6fO2RjftXbobBg==}
-    engines: {node: '>= 12.0.0'}
-    dependencies:
-      glob: 8.1.0
-      graceful-fs: 4.2.11
-      lazystream: 1.0.1
-      lodash: 4.17.21
-      normalize-path: 3.0.0
-      readable-stream: 3.6.2
-    dev: false
-
   /archiver@5.3.2:
     resolution: {integrity: sha512-+25nxyyznAXF7Nef3y0EbBeqmGZgeN/BxHX29Rs39djAfaFalmQ89SE6CWyDCHzGL0yt/ycBtNOmGTW0FyGWNw==}
     engines: {node: '>= 10'}
@@ -7454,19 +7244,6 @@ packages:
       readdir-glob: 1.1.3
       tar-stream: 2.2.0
       zip-stream: 4.1.1
-    dev: false
-
-  /archiver@6.0.1:
-    resolution: {integrity: sha512-CXGy4poOLBKptiZH//VlWdFuUC1RESbdZjGjILwBuZ73P7WkAUN0htfSfBq/7k6FRFlpu7bg4JOkj1vU9G6jcQ==}
-    engines: {node: '>= 12.0.0'}
-    dependencies:
-      archiver-utils: 4.0.1
-      async: 3.2.4
-      buffer-crc32: 0.2.13
-      readable-stream: 3.6.2
-      readdir-glob: 1.1.3
-      tar-stream: 3.1.6
-      zip-stream: 5.0.2
     dev: false
 
   /archy@1.0.0:
@@ -8092,6 +7869,7 @@ packages:
     resolution: {integrity: sha512-fpWrvyVHEKyeEvbKZTVOeZF3VSKKWtJxFIxX/jaVPf+cLbGUSitjb49pHLqPV2BUNNZ0LcoeEGfE/YCpyDYHIw==}
     requiresBuild: true
     dev: false
+    optional: true
 
   /babel-core@7.0.0-bridge.0(@babel/core@7.24.4):
     resolution: {integrity: sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==}
@@ -8101,17 +7879,17 @@ packages:
       '@babel/core': 7.24.4
     dev: false
 
-  /babel-jest@29.7.0(@babel/core@7.23.0):
+  /babel-jest@29.7.0(@babel/core@7.24.4):
     resolution: {integrity: sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
       '@babel/core': ^7.8.0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.24.4
       '@jest/transform': 29.7.0
       '@types/babel__core': 7.20.5
       babel-plugin-istanbul: 6.1.1
-      babel-preset-jest: 29.6.3(@babel/core@7.23.0)
+      babel-preset-jest: 29.6.3(@babel/core@7.24.4)
       chalk: 4.1.2
       graceful-fs: 4.2.11
       slash: 3.0.0
@@ -8178,26 +7956,6 @@ packages:
       - supports-color
     dev: false
 
-  /babel-preset-current-node-syntax@1.0.1(@babel/core@7.23.0):
-    resolution: {integrity: sha512-M7LQ0bxarkxQoN+vz5aJPsLBn77n8QgTFmo8WK0/44auK2xlCXrYcUxHFxgU7qW5Yzw/CjmLRK2uJzaCd7LvqQ==}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    dependencies:
-      '@babel/core': 7.23.0
-      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.23.0)
-      '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.23.0)
-      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.23.0)
-      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.23.0)
-      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.23.0)
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.23.0)
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.23.0)
-      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.23.0)
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.23.0)
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.23.0)
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.23.0)
-      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.23.0)
-    dev: true
-
   /babel-preset-current-node-syntax@1.0.1(@babel/core@7.23.7):
     resolution: {integrity: sha512-M7LQ0bxarkxQoN+vz5aJPsLBn77n8QgTFmo8WK0/44auK2xlCXrYcUxHFxgU7qW5Yzw/CjmLRK2uJzaCd7LvqQ==}
     peerDependencies:
@@ -8218,15 +7976,35 @@ packages:
       '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.23.7)
     dev: true
 
-  /babel-preset-jest@29.6.3(@babel/core@7.23.0):
+  /babel-preset-current-node-syntax@1.0.1(@babel/core@7.24.4):
+    resolution: {integrity: sha512-M7LQ0bxarkxQoN+vz5aJPsLBn77n8QgTFmo8WK0/44auK2xlCXrYcUxHFxgU7qW5Yzw/CjmLRK2uJzaCd7LvqQ==}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.24.4
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.24.4)
+      '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.24.4)
+      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.24.4)
+      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.24.4)
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.24.4)
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.24.4)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.24.4)
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.24.4)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.24.4)
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.24.4)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.24.4)
+      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.24.4)
+    dev: true
+
+  /babel-preset-jest@29.6.3(@babel/core@7.24.4):
     resolution: {integrity: sha512-0B3bhxR6snWXJZtR/RliHTDPRgn1sNHOR0yVtq/IiQFyuOVjFS+wuio/R4gSNkyYmKmJB4wGZv2NZanmKmTnNA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.24.4
       babel-plugin-jest-hoist: 29.6.3
-      babel-preset-current-node-syntax: 1.0.1(@babel/core@7.23.0)
+      babel-preset-current-node-syntax: 1.0.1(@babel/core@7.24.4)
     dev: true
 
   /bach@1.2.0:
@@ -8651,27 +8429,27 @@ packages:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
     dev: false
 
-  /cdktf-cli@0.20.4(ink@3.2.0)(react@17.0.2):
-    resolution: {integrity: sha512-L4Z9cF5zG5gpEUf1zGXugmyRiQDFDlgreyqLUV3hedz4K54JFpV0CjH/NdAq4jqa150/1WimjnNwCjoygTxIBA==}
+  /cdktf-cli@0.20.7(ink@3.2.0)(react@17.0.2):
+    resolution: {integrity: sha512-muEJhxWHZLv1Rayz2t7W3gP1zZbCE4DPFq3gNo4G667TzrwdY7XWreeze8Pj7i3mkQu+K492cSVdWBYKa3AJpg==}
     hasBin: true
     dependencies:
-      '@cdktf/cli-core': 0.20.4(react@17.0.2)
-      '@cdktf/commons': 0.20.4(constructs@10.1.167)
-      '@cdktf/hcl-tools': 0.20.4
-      '@cdktf/hcl2cdk': 0.20.4(constructs@10.1.167)
-      '@cdktf/hcl2json': 0.20.4
+      '@cdktf/cli-core': 0.20.7(react@17.0.2)
+      '@cdktf/commons': 0.20.7(constructs@10.1.167)
+      '@cdktf/hcl-tools': 0.20.7
+      '@cdktf/hcl2cdk': 0.20.7(constructs@10.1.167)
+      '@cdktf/hcl2json': 0.20.7
       '@inquirer/prompts': 2.3.1
-      '@sentry/node': 7.101.1
-      cdktf: 0.20.4(constructs@10.1.167)
+      '@sentry/node': 7.110.0
+      cdktf: 0.20.7(constructs@10.1.167)
       ci-info: 3.9.0
-      codemaker: 1.94.0
+      codemaker: 1.95.0
       constructs: 10.1.167
       cross-spawn: 7.0.3
       https-proxy-agent: 5.0.1
       ink-select-input: 4.2.2(ink@3.2.0)(react@17.0.2)
       ink-table: 3.1.0(ink@3.2.0)(react@17.0.2)
-      jsii: 5.3.19
-      jsii-pacmak: 1.94.0
+      jsii: 5.3.29
+      jsii-pacmak: 1.95.0
       minimatch: 5.1.6
       node-fetch: 2.7.0
       pidtree: 0.6.0
@@ -8692,30 +8470,24 @@ packages:
       - utf-8-validate
     dev: false
 
-  /cdktf@0.20.4(constructs@10.1.167):
-    resolution: {integrity: sha512-4vgJ8TLik1xse5B8gMcWoE2DkdnkhiTVVyvE+j7dNoCpDApqkINY8MpiZjgCQ4HQ2H/wjRrVAD80bV9JaHixRQ==}
+  /cdktf@0.20.7(constructs@10.1.167):
+    resolution: {integrity: sha512-7za8QQYM1G0/6JUCYY+5smwNfNfbiZVPCMD7SeX2rTYmOLaGEkHZtMvuUTEKSqsE56fKudnfVd2J2edz2CETFg==}
     peerDependencies:
       constructs: ^10.0.25
     dependencies:
-      archiver: 6.0.1
       constructs: 10.1.167
-      json-stable-stringify: 1.1.1
-      semver: 7.6.0
     dev: false
     bundledDependencies:
       - archiver
       - json-stable-stringify
       - semver
 
-  /cdktf@0.20.4(constructs@10.3.0):
-    resolution: {integrity: sha512-4vgJ8TLik1xse5B8gMcWoE2DkdnkhiTVVyvE+j7dNoCpDApqkINY8MpiZjgCQ4HQ2H/wjRrVAD80bV9JaHixRQ==}
+  /cdktf@0.20.7(constructs@10.3.0):
+    resolution: {integrity: sha512-7za8QQYM1G0/6JUCYY+5smwNfNfbiZVPCMD7SeX2rTYmOLaGEkHZtMvuUTEKSqsE56fKudnfVd2J2edz2CETFg==}
     peerDependencies:
       constructs: ^10.0.25
     dependencies:
-      archiver: 6.0.1
       constructs: 10.3.0
-      json-stable-stringify: 1.1.1
-      semver: 7.6.0
     dev: false
     bundledDependencies:
       - archiver
@@ -9085,8 +8857,8 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /codemaker@1.94.0:
-    resolution: {integrity: sha512-V+896C7RojQVfG0UlOXaFfVVxmFb08rPtJvzcxhdJfowc2o6xGwGG0OpWSLHy6fQrmt4BxLXnKZ6Xeuqt4aKjw==}
+  /codemaker@1.95.0:
+    resolution: {integrity: sha512-q/U2NeZSaKnVMarOi+BR8MbaHEFKVmBefTSSXj/0W4OBarw/uUT2qCPojYF16gJtfFz7qCkJeuP+zYDq+xNEpg==}
     engines: {node: '>= 14.17.0'}
     dependencies:
       camelcase: 6.3.0
@@ -9233,16 +9005,6 @@ packages:
     dependencies:
       buffer-crc32: 0.2.13
       crc32-stream: 4.0.3
-      normalize-path: 3.0.0
-      readable-stream: 3.6.2
-    dev: false
-
-  /compress-commons@5.0.3:
-    resolution: {integrity: sha512-/UIcLWvwAQyVibgpQDPtfNM3SvqN7G9elAPAV7GM0L53EbNWwWiCsWtK8Fwed/APEbptPHXs5PuW+y8Bq8lFTA==}
-    engines: {node: '>= 12.0.0'}
-    dependencies:
-      crc-32: 1.2.2
-      crc32-stream: 5.0.1
       normalize-path: 3.0.0
       readable-stream: 3.6.2
     dev: false
@@ -9405,15 +9167,7 @@ packages:
       readable-stream: 3.6.2
     dev: false
 
-  /crc32-stream@5.0.1:
-    resolution: {integrity: sha512-lO1dFui+CEUh/ztYIpgpKItKW9Bb4NWakCRJrnqAbFIYD+OZAwb2VfD5T5eXMw2FNcsDHkQcNl/Wh3iVXYwU6g==}
-    engines: {node: '>= 12.0.0'}
-    dependencies:
-      crc-32: 1.2.2
-      readable-stream: 3.6.2
-    dev: false
-
-  /create-jest@29.7.0:
+  /create-jest@29.7.0(@types/node@20.11.16)(ts-node@10.9.2):
     resolution: {integrity: sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -9422,26 +9176,7 @@ packages:
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@20.11.16)
-      jest-util: 29.7.0
-      prompts: 2.4.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-    dev: true
-
-  /create-jest@29.7.0(@types/node@20.8.7)(ts-node@10.9.2):
-    resolution: {integrity: sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    hasBin: true
-    dependencies:
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      exit: 0.1.2
-      graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@20.8.7)(ts-node@10.9.2)
+      jest-config: 29.7.0(@types/node@20.11.16)(ts-node@10.9.2)
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -10047,7 +9782,7 @@ packages:
     dependencies:
       semver: 7.6.0
       shelljs: 0.8.5
-      typescript: 5.5.0-dev.20240513
+      typescript: 5.5.0-dev.20240516
     dev: false
 
   /dset@3.1.3:
@@ -10870,7 +10605,7 @@ packages:
       get-stream: 5.2.0
       yauzl: 2.10.0
     optionalDependencies:
-      '@types/yauzl': 2.10.1
+      '@types/yauzl': 2.10.3
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -11209,6 +10944,17 @@ packages:
     peerDependenciesMeta:
       debug:
         optional: true
+    dev: true
+
+  /follow-redirects@1.15.6:
+    resolution: {integrity: sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+    dev: false
 
   /for-each@0.3.3:
     resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}
@@ -11620,18 +11366,6 @@ packages:
       chokidar: 3.6.0
     dev: true
 
-  /glob@10.3.10:
-    resolution: {integrity: sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==}
-    engines: {node: '>=16 || 14 >=14.17'}
-    hasBin: true
-    dependencies:
-      foreground-child: 3.1.1
-      jackspeak: 2.3.6
-      minimatch: 9.0.4
-      minipass: 7.0.4
-      path-scurry: 1.10.2
-    dev: false
-
   /glob@10.3.12:
     resolution: {integrity: sha512-TCNv8vJ+xz4QiqTpfOJA7HvYv+tNIRHKfUWw/q+v2jdgN4ebz+KY9tGx5J4rHP0o84mNP+ApH66HRX8us3Khqg==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -11663,17 +11397,6 @@ packages:
       minimatch: 3.1.2
       once: 1.4.0
       path-is-absolute: 1.0.1
-
-  /glob@8.1.0:
-    resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
-    engines: {node: '>=12'}
-    dependencies:
-      fs.realpath: 1.0.0
-      inflight: 1.0.6
-      inherits: 2.0.4
-      minimatch: 5.1.6
-      once: 1.4.0
-    dev: false
 
   /global-modules@0.2.3:
     resolution: {integrity: sha512-JeXuCbvYzYXcwE6acL9V2bAOeSIGl4dD+iwLY9iUx2VBJJ80R18HCn+JCwHM9Oegdfya3lEkGCdaRkSyc10hDA==}
@@ -11848,7 +11571,7 @@ packages:
       yargs: 16.2.0
     dev: true
 
-  /gulp-postcss@9.0.1(postcss@8.4.31):
+  /gulp-postcss@9.0.1(postcss@8.4.31)(ts-node@10.9.2):
     resolution: {integrity: sha512-9QUHam5JyXwGUxaaMvoFQVT44tohpEFpM8xBdPfdwTYGM0AItS1iTQz0MpsF8Jroh7GF5Jt2GVPaYgvy8qD2Fw==}
     engines: {node: ^10 || ^12 || >=14}
     peerDependencies:
@@ -11857,7 +11580,7 @@ packages:
       fancy-log: 1.3.3
       plugin-error: 1.0.1
       postcss: 8.4.31
-      postcss-load-config: 3.1.4(postcss@8.4.31)
+      postcss-load-config: 3.1.4(postcss@8.4.31)(ts-node@10.9.2)
       vinyl-sourcemaps-apply: 0.2.1
     transitivePeerDependencies:
       - ts-node
@@ -12504,7 +12227,7 @@ packages:
       lodash: 4.17.21
       patch-console: 1.0.0
       react: 17.0.2
-      react-devtools-core: 4.28.4
+      react-devtools-core: 4.28.5
       react-reconciler: 0.26.2(react@17.0.2)
       scheduler: 0.20.2
       signal-exit: 3.0.7
@@ -13249,35 +12972,7 @@ packages:
       - supports-color
     dev: true
 
-  /jest-cli@29.7.0:
-    resolution: {integrity: sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    hasBin: true
-    peerDependencies:
-      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
-    peerDependenciesMeta:
-      node-notifier:
-        optional: true
-    dependencies:
-      '@jest/core': 29.7.0
-      '@jest/test-result': 29.7.0
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      create-jest: 29.7.0
-      exit: 0.1.2
-      import-local: 3.1.0
-      jest-config: 29.7.0(@types/node@20.11.16)
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-    dev: true
-
-  /jest-cli@29.7.0(@types/node@20.8.7)(ts-node@10.9.2):
+  /jest-cli@29.7.0(@types/node@20.11.16)(ts-node@10.9.2):
     resolution: {integrity: sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -13291,10 +12986,10 @@ packages:
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@20.8.7)(ts-node@10.9.2)
+      create-jest: 29.7.0(@types/node@20.11.16)(ts-node@10.9.2)
       exit: 0.1.2
       import-local: 3.1.0
-      jest-config: 29.7.0(@types/node@20.8.7)(ts-node@10.9.2)
+      jest-config: 29.7.0(@types/node@20.11.16)(ts-node@10.9.2)
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -13303,46 +12998,6 @@ packages:
       - babel-plugin-macros
       - supports-color
       - ts-node
-    dev: true
-
-  /jest-config@29.7.0(@types/node@20.11.16):
-    resolution: {integrity: sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    peerDependencies:
-      '@types/node': '*'
-      ts-node: '>=9.0.0'
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      ts-node:
-        optional: true
-    dependencies:
-      '@babel/core': 7.23.0
-      '@jest/test-sequencer': 29.7.0
-      '@jest/types': 29.6.3
-      '@types/node': 20.11.16
-      babel-jest: 29.7.0(@babel/core@7.23.0)
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      deepmerge: 4.3.1
-      glob: 7.2.3
-      graceful-fs: 4.2.11
-      jest-circus: 29.7.0
-      jest-environment-node: 29.7.0
-      jest-get-type: 29.6.3
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-runner: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      micromatch: 4.0.5
-      parse-json: 5.2.0
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
     dev: true
 
   /jest-config@29.7.0(@types/node@20.11.16)(ts-node@10.9.2):
@@ -13357,52 +13012,11 @@ packages:
       ts-node:
         optional: true
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.24.4
       '@jest/test-sequencer': 29.7.0
       '@jest/types': 29.6.3
       '@types/node': 20.11.16
-      babel-jest: 29.7.0(@babel/core@7.23.0)
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      deepmerge: 4.3.1
-      glob: 7.2.3
-      graceful-fs: 4.2.11
-      jest-circus: 29.7.0
-      jest-environment-node: 29.7.0
-      jest-get-type: 29.6.3
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-runner: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      micromatch: 4.0.5
-      parse-json: 5.2.0
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-      ts-node: 10.9.2(@types/node@20.11.16)(typescript@5.3.3)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-    dev: true
-
-  /jest-config@29.7.0(@types/node@20.8.7)(ts-node@10.9.2):
-    resolution: {integrity: sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    peerDependencies:
-      '@types/node': '*'
-      ts-node: '>=9.0.0'
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      ts-node:
-        optional: true
-    dependencies:
-      '@babel/core': 7.23.0
-      '@jest/test-sequencer': 29.7.0
-      '@jest/types': 29.6.3
-      '@types/node': 20.8.7
-      babel-jest: 29.7.0(@babel/core@7.23.0)
+      babel-jest: 29.7.0(@babel/core@7.24.4)
       chalk: 4.1.2
       ci-info: 3.9.0
       deepmerge: 4.3.1
@@ -13560,7 +13174,7 @@ packages:
       jest-runner: ^29.3.1
     dependencies:
       expect-playwright: 0.8.0
-      jest: 29.7.0
+      jest: 29.7.0(@types/node@20.11.16)(ts-node@10.9.2)
       jest-circus: 29.7.0
       jest-environment-node: 29.7.0
       jest-process-manager: 0.4.0
@@ -13704,10 +13318,10 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@babel/core': 7.23.7
-      '@babel/generator': 7.23.0
+      '@babel/generator': 7.24.4
       '@babel/plugin-syntax-jsx': 7.22.5(@babel/core@7.23.7)
       '@babel/plugin-syntax-typescript': 7.22.5(@babel/core@7.23.7)
-      '@babel/types': 7.23.6
+      '@babel/types': 7.24.0
       '@jest/expect-utils': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
@@ -13759,7 +13373,7 @@ packages:
     dependencies:
       ansi-escapes: 6.2.0
       chalk: 5.3.0
-      jest: 29.7.0
+      jest: 29.7.0(@types/node@20.11.16)(ts-node@10.9.2)
       jest-regex-util: 29.6.3
       jest-watcher: 29.7.0
       slash: 5.1.0
@@ -13791,28 +13405,7 @@ packages:
       supports-color: 8.1.1
     dev: true
 
-  /jest@29.7.0:
-    resolution: {integrity: sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    hasBin: true
-    peerDependencies:
-      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
-    peerDependenciesMeta:
-      node-notifier:
-        optional: true
-    dependencies:
-      '@jest/core': 29.7.0
-      '@jest/types': 29.6.3
-      import-local: 3.1.0
-      jest-cli: 29.7.0
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-    dev: true
-
-  /jest@29.7.0(@types/node@20.8.7)(ts-node@10.9.2):
+  /jest@29.7.0(@types/node@20.11.16)(ts-node@10.9.2):
     resolution: {integrity: sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -13825,7 +13418,7 @@ packages:
       '@jest/core': 29.7.0(ts-node@10.9.2)
       '@jest/types': 29.6.3
       import-local: 3.1.0
-      jest-cli: 29.7.0(@types/node@20.8.7)(ts-node@10.9.2)
+      jest-cli: 29.7.0(@types/node@20.11.16)(ts-node@10.9.2)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -13948,21 +13541,21 @@ packages:
     engines: {node: '>=4'}
     hasBin: true
 
-  /jsii-pacmak@1.94.0:
-    resolution: {integrity: sha512-L5s3RZ0AOx1XfAhXsEjyeCteVrw6nwJLynL+t93eXVDcw7NFT7S0fCFXzQ4lpYQ23P/yVpSIy32J3zpUOf4uDQ==}
+  /jsii-pacmak@1.95.0:
+    resolution: {integrity: sha512-h/eo3p3jG4/Wtb9WdavvcgXzyN5QXZck3k0xvIWp5SKxFLorQ+TWhY7BHG0e+VXl+mxcni6BuQ5wFLavq65RQQ==}
     engines: {node: '>= 14.17.0'}
     hasBin: true
     dependencies:
-      '@jsii/check-node': 1.94.0
-      '@jsii/spec': 1.95.0
+      '@jsii/check-node': 1.95.0
+      '@jsii/spec': 1.98.0
       clone: 2.1.2
-      codemaker: 1.94.0
+      codemaker: 1.95.0
       commonmark: 0.30.0
       escape-string-regexp: 4.0.0
       fs-extra: 10.1.0
-      jsii-reflect: 1.95.0
-      jsii-rosetta: 1.95.0
-      semver: 7.5.4
+      jsii-reflect: 1.98.0
+      jsii-rosetta: 1.98.0
+      semver: 7.6.0
       spdx-license-list: 6.9.0
       xmlbuilder: 15.1.1
       yargs: 16.2.0
@@ -13970,32 +13563,32 @@ packages:
       - supports-color
     dev: false
 
-  /jsii-reflect@1.95.0:
-    resolution: {integrity: sha512-/o/UdqX1MtOmavwAF+cqMAHs7Ewi/j2a9PVGYTzi3U4M5Cvxsyrk7e1EWKvw/NHK0JZmmKd1UqE0Mz5EHqZSxw==}
+  /jsii-reflect@1.98.0:
+    resolution: {integrity: sha512-HulKk6pQOk0zkqJXRaweV5PezvAghZAX4cuB7i0sBA0/kz1ypqB1KFhBiZ1PLeeMzAfb1/WmCF2UTu9xzQit4w==}
     engines: {node: '>= 14.17.0'}
     hasBin: true
     dependencies:
-      '@jsii/check-node': 1.95.0
-      '@jsii/spec': 1.95.0
+      '@jsii/check-node': 1.98.0
+      '@jsii/spec': 1.98.0
       chalk: 4.1.2
       fs-extra: 10.1.0
-      oo-ascii-tree: 1.95.0
+      oo-ascii-tree: 1.98.0
       yargs: 16.2.0
     dev: false
 
-  /jsii-rosetta@1.95.0:
-    resolution: {integrity: sha512-J9tQy6wT7ERgXC73ubjWmkp8EO5SHPn9eDkTKLmAi+AkMAOAJEb1oxaA1bKPBf/2SQp6wDU5TUfEpx6ukSmc1g==}
+  /jsii-rosetta@1.98.0:
+    resolution: {integrity: sha512-3f28gd2t5GkYEjxm6oZ8U2kgF3c/0FPx+AL5GOtwhiOG6Lxt9Uy8jgJPqFZ0Ynr9JOWQSiNXmMEq/Iw/LnH+3A==}
     engines: {node: '>= 14.17.0'}
     hasBin: true
     dependencies:
-      '@jsii/check-node': 1.95.0
-      '@jsii/spec': 1.95.0
+      '@jsii/check-node': 1.98.0
+      '@jsii/spec': 1.98.0
       '@xmldom/xmldom': 0.8.10
       commonmark: 0.30.0
       fast-glob: 3.3.2
-      jsii: 1.95.0
+      jsii: 1.98.0
       semver: 7.6.0
-      semver-intersect: 1.4.0
+      semver-intersect: 1.5.0
       stream-json: 1.8.0
       typescript: 3.9.10
       workerpool: 6.5.1
@@ -14004,18 +13597,18 @@ packages:
       - supports-color
     dev: false
 
-  /jsii-rosetta@5.3.19:
-    resolution: {integrity: sha512-+fQ62AbrgDDN7i6dC6JILVFFOppCABpnzS/eEtbGSMdSy5EF+5kfl61D3UJJEloG+an/WS3VwuiEu1POG1tVkA==}
+  /jsii-rosetta@5.3.28:
+    resolution: {integrity: sha512-pvfaaMYJhsGz9BXmQenlC+aey2HTRiPwlTr7FcH4wr0THkKbIwChPpS26YWSGyNLmTqDZUvmQv+xDtMx5qFXGg==}
     engines: {node: '>= 18.12.0'}
     hasBin: true
     dependencies:
-      '@jsii/check-node': 1.94.0
-      '@jsii/spec': 1.95.0
+      '@jsii/check-node': 1.95.0
+      '@jsii/spec': 1.98.0
       '@xmldom/xmldom': 0.8.10
       chalk: 4.1.2
       commonmark: 0.31.0
       fast-glob: 3.3.2
-      jsii: 5.3.19
+      jsii: 5.3.29
       semver: 7.6.0
       semver-intersect: 1.5.0
       stream-json: 1.8.0
@@ -14031,28 +13624,28 @@ packages:
     hasBin: true
     dependencies:
       fs-extra: 9.1.0
-      jsii: 5.3.19
-      jsii-pacmak: 1.94.0
+      jsii: 5.3.29
+      jsii-pacmak: 1.95.0
       ncp: 2.0.0
       yargs: 15.4.1
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /jsii@1.95.0:
-    resolution: {integrity: sha512-GvBqcZrhKZ5WV6u44w88aFym8G4Xkw9QRZuAAGYHOFJWiK/fyqeRPPgPkEBqfE+xs412JvGVdejUodKLlhEP9w==}
+  /jsii@1.98.0:
+    resolution: {integrity: sha512-P/Q/mlcbZsJqZDE4zJ+GyLLZRyMPqlx+Fb/p6oDei9JA+fBmBX5Adbw4B8+VClZqvr8I0PxHxLk06n+EVQn3cQ==}
     engines: {node: '>= 14.17.0'}
     hasBin: true
     dependencies:
-      '@jsii/check-node': 1.95.0
-      '@jsii/spec': 1.95.0
+      '@jsii/check-node': 1.98.0
+      '@jsii/spec': 1.98.0
       case: 1.6.3
       chalk: 4.1.2
       fast-deep-equal: 3.1.3
       fs-extra: 10.1.0
       log4js: 6.9.1
       semver: 7.6.0
-      semver-intersect: 1.4.0
+      semver-intersect: 1.5.0
       sort-json: 2.0.1
       spdx-license-list: 6.9.0
       typescript: 3.9.10
@@ -14061,13 +13654,13 @@ packages:
       - supports-color
     dev: false
 
-  /jsii@5.3.19:
-    resolution: {integrity: sha512-rc8kkEvnthCG0DS1TK+NY+cl+fkH+OJ4FHCs6o3a8sO2zekMOYb09uJDVHHbxBMlIJXuNKhpp+UYehVnHFkmIA==}
+  /jsii@5.3.29:
+    resolution: {integrity: sha512-vEEOtjD8s/C8ORHvN87Bt9jHcY1diJoC1sS+TVnCkeb4V9q5fOEVr4gl/FsU5ea8dSWZHdd7VqCtr0jYAwKleg==}
     engines: {node: '>= 18.12.0'}
     hasBin: true
     dependencies:
-      '@jsii/check-node': 1.94.0
-      '@jsii/spec': 1.95.0
+      '@jsii/check-node': 1.95.0
+      '@jsii/spec': 1.98.0
       case: 1.6.3
       chalk: 4.1.2
       downlevel-dts: 0.11.0
@@ -14106,16 +13699,6 @@ packages:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
     dev: true
 
-  /json-stable-stringify@1.1.1:
-    resolution: {integrity: sha512-SU/971Kt5qVQfJpyDveVhQ/vya+5hvrjClFOcr8c0Fq5aODJjMwutrOfCU+eCnVD5gpx1Q3fEqkyom77zH1iIg==}
-    engines: {node: '>= 0.4'}
-    dependencies:
-      call-bind: 1.0.5
-      isarray: 2.0.5
-      jsonify: 0.0.1
-      object-keys: 1.1.1
-    dev: false
-
   /json-stringify-safe@5.0.1:
     resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
     dev: false
@@ -14143,10 +13726,6 @@ packages:
       universalify: 2.0.0
     optionalDependencies:
       graceful-fs: 4.2.11
-
-  /jsonify@0.0.1:
-    resolution: {integrity: sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==}
-    dev: false
 
   /jsx-ast-utils@3.3.5:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
@@ -14458,7 +14037,7 @@ packages:
       date-format: 4.0.14
       debug: 4.3.4
       flatted: 3.2.9
-      rfdc: 1.3.0
+      rfdc: 1.3.1
       streamroller: 3.1.5
     transitivePeerDependencies:
       - supports-color
@@ -15740,8 +15319,8 @@ packages:
       mimic-fn: 4.0.0
     dev: false
 
-  /oo-ascii-tree@1.95.0:
-    resolution: {integrity: sha512-e9LWcjDtQIwFHICbeAjv2+RGJUFu3+A6oTjpymH+gfxATqPqcUV5oeGON9a/1uBr8Q0bc2/yEHVp1A/dp1iaog==}
+  /oo-ascii-tree@1.98.0:
+    resolution: {integrity: sha512-+GE7ywhtS6MctbfcO+vZzqIxcFzucZCwmawcwCVo89DxQDakV1JFfFViTXG4A90UzTAsU4tQteGmwDtwOlOXLw==}
     engines: {node: '>= 14.17.0'}
     dev: false
 
@@ -16227,11 +15806,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /pirates@4.0.5:
-    resolution: {integrity: sha512-8V9+HQPupnaXMA23c5hvl69zXvTwTzyAYasnkb0Tts4XvO4CliqONMOnvlq26rkhLC3nWDFBJf73LU1e1VZLaQ==}
-    engines: {node: '>= 6'}
-    dev: true
-
   /pirates@4.0.6:
     resolution: {integrity: sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==}
     engines: {node: '>= 6'}
@@ -16333,7 +15907,7 @@ packages:
       postcss: 8.4.31
     dev: true
 
-  /postcss-load-config@3.1.4(postcss@8.4.31):
+  /postcss-load-config@3.1.4(postcss@8.4.31)(ts-node@10.9.2):
     resolution: {integrity: sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==}
     engines: {node: '>= 10'}
     peerDependencies:
@@ -16347,6 +15921,7 @@ packages:
     dependencies:
       lilconfig: 2.1.0
       postcss: 8.4.31
+      ts-node: 10.9.2(@types/node@20.11.16)(typescript@5.3.3)
       yaml: 1.10.2
     dev: true
 
@@ -16671,8 +16246,8 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: true
 
-  /react-devtools-core@4.28.4:
-    resolution: {integrity: sha512-IUZKLv3CimeM07G3vX4H4loxVpByrzq3HvfTX7v9migalwvLs9ZY5D3S3pKR33U+GguYfBBdMMZyToFhsSE/iQ==}
+  /react-devtools-core@4.28.5:
+    resolution: {integrity: sha512-cq/o30z9W2Wb4rzBefjv5fBalHU0rJGZCHAkf/RHSBWSSYwh8PlQTqqOJmgIIbBtpj27T6FIPXeomIjZtCNVqA==}
     dependencies:
       shell-quote: 1.8.1
       ws: 7.5.9
@@ -17433,8 +17008,8 @@ packages:
     resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
-  /rfdc@1.3.0:
-    resolution: {integrity: sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==}
+  /rfdc@1.3.1:
+    resolution: {integrity: sha512-r5a3l5HzYlIC68TpmYKlxWjmOP6wiPJ1vWv2HeLhNsRZMrCkxeqxiHlQ21oXmQ4F3SiryXBHhAD7JZqvOJjFmg==}
     dev: false
 
   /right-pad@1.0.1:
@@ -17745,12 +17320,6 @@ packages:
     dependencies:
       sver: 1.8.4
     dev: true
-
-  /semver-intersect@1.4.0:
-    resolution: {integrity: sha512-d8fvGg5ycKAq0+I6nfWeCx6ffaWJCsBYU0H2Rq56+/zFePYfT8mXkB3tWBSjR5BerkHNZ5eTPIk1/LBYas35xQ==}
-    dependencies:
-      semver: 5.7.2
-    dev: false
 
   /semver-intersect@1.5.0:
     resolution: {integrity: sha512-BDjWX7yCC0haX4W/zrnV2JaMpVirwaEkGOBmgRQtH++F1N3xl9v7k9H44xfTqwl+yLNNSbMKosoVSTIiJVQ2Pw==}
@@ -18665,6 +18234,7 @@ packages:
       fast-fifo: 1.3.2
       streamx: 2.15.1
     dev: false
+    optional: true
 
   /tar@6.2.0:
     resolution: {integrity: sha512-/Wo7DcT0u5HUV486xg675HtjNd3BXZ6xDbzsCUZPt5iw8bTQ63bP0Raut3mvro9u+CUyq7YQd8Cx55fsZXxqLQ==}
@@ -18946,9 +18516,9 @@ packages:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
     dev: true
 
-  /ts-jest@29.1.1(@babel/core@7.24.4)(esbuild@0.19.12)(jest@29.7.0)(typescript@5.4.2):
-    resolution: {integrity: sha512-D6xjnnbP17cC85nliwGiL+tpoKN0StpgE0TeOjXQTU6MVCfsB4v7aW05CgQ/1OywGb0x/oy9hHFnN+sczTiRaA==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+  /ts-jest@29.1.2(@babel/core@7.24.4)(esbuild@0.19.12)(jest@29.7.0)(typescript@5.4.2):
+    resolution: {integrity: sha512-br6GJoH/WUX4pu7FbZXuWGKGNDuU7b8Uj77g/Sp7puZV6EXzuByl6JrECvm0MzVzSTkSHWTihsXt+5XYER5b+g==}
+    engines: {node: ^16.10.0 || ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:
       '@babel/core': '>=7.0.0-beta.0 <8'
@@ -18971,12 +18541,12 @@ packages:
       bs-logger: 0.2.6
       esbuild: 0.19.12
       fast-json-stable-stringify: 2.1.0
-      jest: 29.7.0(@types/node@20.8.7)(ts-node@10.9.2)
+      jest: 29.7.0(@types/node@20.11.16)(ts-node@10.9.2)
       jest-util: 29.7.0
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
-      semver: 7.5.4
+      semver: 7.6.0
       typescript: 5.4.2
       yargs-parser: 21.1.1
     dev: true
@@ -19336,8 +18906,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  /typescript@5.5.0-dev.20240513:
-    resolution: {integrity: sha512-EaabRW/mNcpehitpeUkoIg8mNRGl5twGUzHJEJE9qTMlvVzoctff/XFZGKrxu9PUUcYluaMQTBNdNuqOZMqvTw==}
+  /typescript@5.5.0-dev.20240516:
+    resolution: {integrity: sha512-MNzi4B6WADePeOrxzfVArpyIW0P3ihAqAU4+l2GiBRbz3M+oIUEJCiLE/o5VMLoUAyPu9mCSshsMcsbpPu9wzQ==}
     engines: {node: '>=14.17'}
     hasBin: true
     dev: false
@@ -19408,10 +18978,6 @@ packages:
       fast-levenshtein: 3.0.0
       last-run: 2.0.0
       undertaker-registry: 2.0.0
-    dev: true
-
-  /undici-types@5.25.3:
-    resolution: {integrity: sha512-Ga1jfYwRn7+cP9v8auvEXN1rX3sWqlayd4HP7OKk4mZWylEmu3KzXDUGrQUN6Ol7qo1gPvB2e5gX6udnyEPgdA==}
     dev: true
 
   /undici-types@5.26.5:
@@ -19979,7 +19545,7 @@ packages:
       - terser
     dev: true
 
-  /vite-plugin-dts@3.8.3(typescript@5.4.2)(vite@5.2.9):
+  /vite-plugin-dts@3.8.3(@types/node@20.11.16)(typescript@5.4.2)(vite@5.2.9):
     resolution: {integrity: sha512-yRHiRosQw7MXdOhmcrVI+kRiB8YEShbSxnADNteK4eZGdEoyOkMHihvO5XOAVlOq8ng9sIqu8vVefDK1zcj3qw==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
@@ -19989,14 +19555,14 @@ packages:
       vite:
         optional: true
     dependencies:
-      '@microsoft/api-extractor': 7.43.0
+      '@microsoft/api-extractor': 7.43.0(@types/node@20.11.16)
       '@rollup/pluginutils': 5.1.0
       '@vue/language-core': 1.8.27(typescript@5.4.2)
       debug: 4.3.4
       kolorist: 1.8.0
       magic-string: 0.30.9
       typescript: 5.4.2
-      vite: 5.2.9
+      vite: 5.2.9(@types/node@20.11.16)
       vue-tsc: 1.8.27(typescript@5.4.2)
     transitivePeerDependencies:
       - '@types/node'
@@ -20050,40 +19616,6 @@ packages:
     optionalDependencies:
       fsevents: 2.3.3
 
-  /vite@5.2.9:
-    resolution: {integrity: sha512-uOQWfuZBlc6Y3W/DTuQ1Sr+oIXWvqljLvS881SVmAj00d5RdgShLcuXWxseWPd4HXwiYBFW/vXHfKFeqj9uQnw==}
-    engines: {node: ^18.0.0 || >=20.0.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': ^18.0.0 || >=20.0.0
-      less: '*'
-      lightningcss: ^1.21.0
-      sass: '*'
-      stylus: '*'
-      sugarss: '*'
-      terser: ^5.4.0
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      less:
-        optional: true
-      lightningcss:
-        optional: true
-      sass:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-    dependencies:
-      esbuild: 0.20.2
-      postcss: 8.4.38
-      rollup: 4.14.3
-    optionalDependencies:
-      fsevents: 2.3.3
-
   /vite@5.2.9(@types/node@20.11.16):
     resolution: {integrity: sha512-uOQWfuZBlc6Y3W/DTuQ1Sr+oIXWvqljLvS881SVmAj00d5RdgShLcuXWxseWPd4HXwiYBFW/vXHfKFeqj9uQnw==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -20118,7 +19650,6 @@ packages:
       rollup: 4.14.3
     optionalDependencies:
       fsevents: 2.3.3
-    dev: true
 
   /vitefu@0.2.5(vite@5.1.4):
     resolution: {integrity: sha512-SgHtMLoqaeeGnd2evZ849ZbACbnwQCIwRH57t18FxcXoZop0uQu0uzlIhJBlF/eWVzuce0sHeqPcDo+evVcg8Q==}
@@ -21018,15 +20549,6 @@ packages:
     dependencies:
       archiver-utils: 3.0.4
       compress-commons: 4.1.2
-      readable-stream: 3.6.2
-    dev: false
-
-  /zip-stream@5.0.2:
-    resolution: {integrity: sha512-LfOdrUvPB8ZoXtvOBz6DlNClfvi//b5d56mSWyJi7XbH/HfhOHfUhOqxhT/rUiR7yiktlunqRo+jY6y/cWC/5g==}
-    engines: {node: '>= 12.0.0'}
-    dependencies:
-      archiver-utils: 4.0.1
-      compress-commons: 5.0.3
       readable-stream: 3.6.2
     dev: false
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -242,7 +242,7 @@ importers:
         specifier: ^6.22.3
         version: 6.22.3(react-dom@18.2.0)(react@18.2.0)
       storybook:
-        specifier: ^7.6.19
+        specifier: ^7.6.10
         version: 7.6.19
       zustand:
         specifier: ^4.5.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -242,8 +242,8 @@ importers:
         specifier: ^6.22.3
         version: 6.22.3(react-dom@18.2.0)(react@18.2.0)
       storybook:
-        specifier: ^7.6.10
-        version: 7.6.17
+        specifier: ^7.6.19
+        version: 7.6.19
       zustand:
         specifier: ^4.5.2
         version: 4.5.2(@types/react@18.2.79)(react@18.2.0)
@@ -5229,13 +5229,13 @@ packages:
       - supports-color
     dev: true
 
-  /@storybook/builder-manager@7.6.17:
-    resolution: {integrity: sha512-Sj8hcDYiPCCMfeLzus37czl0zdrAxAz4IyYam2jBjVymrIrcDAFyL1OCZvnq33ft179QYQWhUs9qwzVmlR/ZWg==}
+  /@storybook/builder-manager@7.6.19:
+    resolution: {integrity: sha512-Dt5OLh97xeWh4h2mk9uG0SbCxBKHPhIiHLHAKEIDzIZBdwUhuyncVNDPHW2NlXM+S7U0/iKs2tw05waqh2lHvg==}
     dependencies:
       '@fal-works/esbuild-plugin-global-externals': 2.1.2
-      '@storybook/core-common': 7.6.17
-      '@storybook/manager': 7.6.17
-      '@storybook/node-logger': 7.6.17
+      '@storybook/core-common': 7.6.19
+      '@storybook/manager': 7.6.19
+      '@storybook/node-logger': 7.6.19
       '@types/ejs': 3.1.5
       '@types/find-cache-dir': 3.2.1
       '@yarnpkg/esbuild-plugin-pnp': 3.0.0-rc.15(esbuild@0.18.20)
@@ -5300,23 +5300,35 @@ packages:
       qs: 6.11.2
       telejson: 7.2.0
       tiny-invariant: 1.3.3
+    dev: true
 
-  /@storybook/cli@7.6.17:
-    resolution: {integrity: sha512-1sCo+nCqyR+nKfTcEidVu8XzNoECC7Y1l+uW38/r7s2f/TdDorXaIGAVrpjbSaXSoQpx5DxYJVaKCcQuOgqwcA==}
+  /@storybook/channels@7.6.19:
+    resolution: {integrity: sha512-2JGh+i95GwjtjqWqhtEh15jM5ifwbRGmXeFqkY7dpdHH50EEWafYHr2mg3opK3heVDwg0rJ/VBptkmshloXuvA==}
+    dependencies:
+      '@storybook/client-logger': 7.6.19
+      '@storybook/core-events': 7.6.19
+      '@storybook/global': 5.0.0
+      qs: 6.11.2
+      telejson: 7.2.0
+      tiny-invariant: 1.3.3
+    dev: false
+
+  /@storybook/cli@7.6.19:
+    resolution: {integrity: sha512-7OVy7nPgkLfgivv6/dmvoyU6pKl9EzWFk+g9izyQHiM/jS8jOiEyn6akG8Ebj6k5pWslo5lgiXUSW+cEEZUnqQ==}
     hasBin: true
     dependencies:
       '@babel/core': 7.24.4
       '@babel/preset-env': 7.23.8(@babel/core@7.24.4)
       '@babel/types': 7.24.0
       '@ndelangen/get-tarball': 3.0.9
-      '@storybook/codemod': 7.6.17
-      '@storybook/core-common': 7.6.17
-      '@storybook/core-events': 7.6.17
-      '@storybook/core-server': 7.6.17
-      '@storybook/csf-tools': 7.6.17
-      '@storybook/node-logger': 7.6.17
-      '@storybook/telemetry': 7.6.17
-      '@storybook/types': 7.6.17
+      '@storybook/codemod': 7.6.19
+      '@storybook/core-common': 7.6.19
+      '@storybook/core-events': 7.6.19
+      '@storybook/core-server': 7.6.19
+      '@storybook/csf-tools': 7.6.19
+      '@storybook/node-logger': 7.6.19
+      '@storybook/telemetry': 7.6.19
+      '@storybook/types': 7.6.19
       '@types/semver': 7.5.8
       '@yarnpkg/fslib': 2.10.3
       '@yarnpkg/libzip': 2.3.0
@@ -5356,17 +5368,24 @@ packages:
     resolution: {integrity: sha512-6WBYqixAXNAXlSaBWwgljWpAu10tPRBJrcFvx2gPUne58EeMM20Gi/iHYBz2kMCY+JLAgeIH7ZxInqwO8vDwiQ==}
     dependencies:
       '@storybook/global': 5.0.0
+    dev: true
 
-  /@storybook/codemod@7.6.17:
-    resolution: {integrity: sha512-JuTmf2u3C4fCnjO7o3dqRgrq3ozNYfWlrRP8xuIdvT7niMap7a396hJtSKqS10FxCgKFcMAOsRgrCalH1dWxUg==}
+  /@storybook/client-logger@7.6.19:
+    resolution: {integrity: sha512-oGzOxbmLmciSIfd5gsxDzPmX8DttWhoYdPKxjMuCuWLTO2TWpkCWp1FTUMWO72mm/6V/FswT/aqpJJBBvdZ3RQ==}
+    dependencies:
+      '@storybook/global': 5.0.0
+    dev: false
+
+  /@storybook/codemod@7.6.19:
+    resolution: {integrity: sha512-bmHE0iEEgWZ65dXCmasd+GreChjPiWkXu2FEa0cJmNz/PqY12GsXGls4ke1TkNTj4gdSZnbtJxbclPZZnib2tQ==}
     dependencies:
       '@babel/core': 7.24.4
       '@babel/preset-env': 7.23.8(@babel/core@7.24.4)
       '@babel/types': 7.24.0
       '@storybook/csf': 0.1.2
-      '@storybook/csf-tools': 7.6.17
-      '@storybook/node-logger': 7.6.17
-      '@storybook/types': 7.6.17
+      '@storybook/csf-tools': 7.6.19
+      '@storybook/node-logger': 7.6.19
+      '@storybook/types': 7.6.19
       '@types/cross-spawn': 6.0.6
       cross-spawn: 7.0.3
       globby: 11.1.0
@@ -5437,32 +5456,71 @@ packages:
     transitivePeerDependencies:
       - encoding
       - supports-color
+    dev: true
+
+  /@storybook/core-common@7.6.19:
+    resolution: {integrity: sha512-njwpGzFJrfbJr/AFxGP8KMrfPfxN85KOfSlxYnQwRm5Z0H1D/lT33LhEBf5m37gaGawHeG7KryxO6RvaioMt2Q==}
+    dependencies:
+      '@storybook/core-events': 7.6.19
+      '@storybook/node-logger': 7.6.19
+      '@storybook/types': 7.6.19
+      '@types/find-cache-dir': 3.2.1
+      '@types/node': 18.19.30
+      '@types/node-fetch': 2.6.11
+      '@types/pretty-hrtime': 1.0.3
+      chalk: 4.1.2
+      esbuild: 0.18.20
+      esbuild-register: 3.5.0(esbuild@0.18.20)
+      file-system-cache: 2.3.0
+      find-cache-dir: 3.3.2
+      find-up: 5.0.0
+      fs-extra: 11.2.0
+      glob: 10.3.12
+      handlebars: 4.7.8
+      lazy-universal-dotenv: 4.0.0
+      node-fetch: 2.7.0
+      picomatch: 2.3.1
+      pkg-dir: 5.0.0
+      pretty-hrtime: 1.0.3
+      resolve-from: 5.0.0
+      ts-dedent: 2.2.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    dev: false
 
   /@storybook/core-events@7.6.17:
     resolution: {integrity: sha512-AriWMCm/k1cxlv10f+jZ1wavThTRpLaN3kY019kHWbYT9XgaSuLU67G7GPr3cGnJ6HuA6uhbzu8qtqVCd6OfXA==}
     dependencies:
       ts-dedent: 2.2.0
+    dev: true
 
-  /@storybook/core-server@7.6.17:
-    resolution: {integrity: sha512-KWGhTTaL1Q14FolcoKKZgytlPJUbH6sbJ1Ptj/84EYWFewcnEgVs0Zlnh1VStRZg+Rd1WC1V4yVd/bbDzxrvQA==}
+  /@storybook/core-events@7.6.19:
+    resolution: {integrity: sha512-K/W6Uvum0ocZSgjbi8hiotpe+wDEHDZlvN+KlPqdh9ae9xDK8aBNBq9IelCoqM+uKO1Zj+dDfSQds7CD781DJg==}
+    dependencies:
+      ts-dedent: 2.2.0
+    dev: false
+
+  /@storybook/core-server@7.6.19:
+    resolution: {integrity: sha512-7mKL73Wv5R2bEl0kJ6QJ9bOu5YY53Idu24QgvTnUdNsQazp2yUONBNwHIrNDnNEXm8SfCi4Mc9o0mmNRMIoiRA==}
     dependencies:
       '@aw-web-design/x-default-browser': 1.4.126
       '@discoveryjs/json-ext': 0.5.7
-      '@storybook/builder-manager': 7.6.17
-      '@storybook/channels': 7.6.17
-      '@storybook/core-common': 7.6.17
-      '@storybook/core-events': 7.6.17
+      '@storybook/builder-manager': 7.6.19
+      '@storybook/channels': 7.6.19
+      '@storybook/core-common': 7.6.19
+      '@storybook/core-events': 7.6.19
       '@storybook/csf': 0.1.2
-      '@storybook/csf-tools': 7.6.17
+      '@storybook/csf-tools': 7.6.19
       '@storybook/docs-mdx': 0.1.0
       '@storybook/global': 5.0.0
-      '@storybook/manager': 7.6.17
-      '@storybook/node-logger': 7.6.17
-      '@storybook/preview-api': 7.6.17
-      '@storybook/telemetry': 7.6.17
-      '@storybook/types': 7.6.17
+      '@storybook/manager': 7.6.19
+      '@storybook/node-logger': 7.6.19
+      '@storybook/preview-api': 7.6.19
+      '@storybook/telemetry': 7.6.19
+      '@storybook/types': 7.6.19
       '@types/detect-port': 1.3.5
-      '@types/node': 18.19.18
+      '@types/node': 18.19.30
       '@types/pretty-hrtime': 1.0.3
       '@types/semver': 7.5.8
       better-opn: 3.0.2
@@ -5517,6 +5575,23 @@ packages:
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /@storybook/csf-tools@7.6.19:
+    resolution: {integrity: sha512-8Vzia3cHhDdGHuS3XKXJReCRxmfRq3vmTm/Te9yKZnPSAsC58CCKcMh8FNEFJ44vxYF9itKTkRutjGs+DprKLQ==}
+    dependencies:
+      '@babel/generator': 7.24.4
+      '@babel/parser': 7.24.4
+      '@babel/traverse': 7.24.1
+      '@babel/types': 7.24.0
+      '@storybook/csf': 0.1.2
+      '@storybook/types': 7.6.19
+      fs-extra: 11.2.0
+      recast: 0.23.6
+      ts-dedent: 2.2.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
 
   /@storybook/csf@0.1.2:
     resolution: {integrity: sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==}
@@ -5579,8 +5654,8 @@ packages:
       - react-dom
     dev: true
 
-  /@storybook/manager@7.6.17:
-    resolution: {integrity: sha512-A1LDDIqMpwRzq/dqkbbiza0QI04o4ZHCl2a3UMDZUV/+QLc2nsr2DAaLk4CVL4/cIc5zGqmIcaOTvprx2YKVBw==}
+  /@storybook/manager@7.6.19:
+    resolution: {integrity: sha512-fZWQcf59x4P0iiBhrL74PZrqKJAPuk9sWjP8BIkGbf8wTZtUunbY5Sv4225fOL4NLJbuX9/RYLUPoxQ3nucGHA==}
     dev: false
 
   /@storybook/mdx2-csf@1.1.0:
@@ -5589,6 +5664,11 @@ packages:
 
   /@storybook/node-logger@7.6.17:
     resolution: {integrity: sha512-w59MQuXhhUNrUVmVkXhMwIg2nvFWjdDczLTwYLorhfsE36CWeUOY5QCZWQy0Qf/h+jz8Uo7Evy64qn18v9C4wA==}
+    dev: true
+
+  /@storybook/node-logger@7.6.19:
+    resolution: {integrity: sha512-2g29QC44Zl1jKY37DmQ0/dO7+VSKnGgPI/x0mwVwQffypSapxH3rwLLT5Q5XLHeFyD+fhRu5w9Cj4vTGynJgpA==}
+    dev: false
 
   /@storybook/postinstall@7.6.17:
     resolution: {integrity: sha512-WaWqB8o9vUc9aaVls+povQSVirf1Xd1LZcVhUKfAocAF3mzYUsnJsVqvnbjRj/F96UFVihOyDt9Zjl/9OvrCvQ==}
@@ -5611,6 +5691,26 @@ packages:
       synchronous-promise: 2.0.17
       ts-dedent: 2.2.0
       util-deprecate: 1.0.2
+    dev: true
+
+  /@storybook/preview-api@7.6.19:
+    resolution: {integrity: sha512-04hdMSQucroJT4dBjQzRd7ZwH2hij8yx2nm5qd4HYGkd1ORkvlH6GOLph4XewNJl5Um3xfzFQzBhvkqvG0WaCQ==}
+    dependencies:
+      '@storybook/channels': 7.6.19
+      '@storybook/client-logger': 7.6.19
+      '@storybook/core-events': 7.6.19
+      '@storybook/csf': 0.1.2
+      '@storybook/global': 5.0.0
+      '@storybook/types': 7.6.19
+      '@types/qs': 6.9.11
+      dequal: 2.0.3
+      lodash: 4.17.21
+      memoizerific: 1.11.3
+      qs: 6.11.2
+      synchronous-promise: 2.0.17
+      ts-dedent: 2.2.0
+      util-deprecate: 1.0.2
+    dev: false
 
   /@storybook/preview@7.6.17:
     resolution: {integrity: sha512-LvkMYK/y6alGjwRVNDIKL1lFlbyZ0H0c8iAbcQkiMoaFiujMQyVswMDKlWcj42Upfr/B1igydiruomc+eUt0mw==}
@@ -5701,12 +5801,12 @@ packages:
       qs: 6.11.2
     dev: true
 
-  /@storybook/telemetry@7.6.17:
-    resolution: {integrity: sha512-WOcOAmmengYnGInH98Px44F47DSpLyk20BM+Z/IIQDzfttGOLlxNqBBG1XTEhNRn+AYuk4aZ2JEed2lCjVIxcA==}
+  /@storybook/telemetry@7.6.19:
+    resolution: {integrity: sha512-rA5xum4I36M57iiD3uzmW0MOdpl0vEpHWBSAa5hK0a0ALPeY9TgAsQlI/0dSyNYJ/K7aczEEN6d4qm1NC4u10A==}
     dependencies:
-      '@storybook/client-logger': 7.6.17
-      '@storybook/core-common': 7.6.17
-      '@storybook/csf-tools': 7.6.17
+      '@storybook/client-logger': 7.6.19
+      '@storybook/core-common': 7.6.19
+      '@storybook/csf-tools': 7.6.19
       chalk: 4.1.2
       detect-package-manager: 2.0.1
       fetch-retry: 5.0.6
@@ -5805,6 +5905,16 @@ packages:
       '@types/babel__core': 7.20.5
       '@types/express': 4.17.21
       file-system-cache: 2.3.0
+    dev: true
+
+  /@storybook/types@7.6.19:
+    resolution: {integrity: sha512-DeGYrRPRMGTVfT7o2rEZtRzyLT2yKTI2exgpnxbwPWEFAduZCSfzBrcBXZ/nb5B0pjA9tUNWls1YzGkJGlkhpg==}
+    dependencies:
+      '@storybook/channels': 7.6.19
+      '@types/babel__core': 7.20.5
+      '@types/express': 4.17.21
+      file-system-cache: 2.3.0
+    dev: false
 
   /@swc/core-darwin-arm64@1.3.105:
     resolution: {integrity: sha512-buWeweLVDXXmcnfIemH4PGnpjwsDTUGitnPchdftb0u1FU8zSSP/lw/pUCBDG/XvWAp7c/aFxgN4CyG0j7eayA==}
@@ -6283,6 +6393,7 @@ packages:
     resolution: {integrity: sha512-80CP7B8y4PzZF0GWx15/gVWRrB5y/bIjNI84NK3cmQJu0WZwvmj2WMA5LcofQFVfLqqCSp545+U2LsrVzX36Zg==}
     dependencies:
       undici-types: 5.26.5
+    dev: true
 
   /@types/node@18.19.30:
     resolution: {integrity: sha512-453z1zPuJLVDbyahaa1sSD5C2sht6ZpHp5rgJNs+H8YGqhluCXcuOUmBYsAo0Tos0cHySJ3lVUGbGgLlqIkpyg==}
@@ -7233,6 +7344,18 @@ packages:
       readable-stream: 3.6.2
     dev: false
 
+  /archiver-utils@4.0.1:
+    resolution: {integrity: sha512-Q4Q99idbvzmgCTEAAhi32BkOyq8iVI5EwdO0PmBDSGIzzjYNdcFn7Q7k3OzbLy4kLUPXfJtG6fO2RjftXbobBg==}
+    engines: {node: '>= 12.0.0'}
+    dependencies:
+      glob: 8.1.0
+      graceful-fs: 4.2.11
+      lazystream: 1.0.1
+      lodash: 4.17.21
+      normalize-path: 3.0.0
+      readable-stream: 3.6.2
+    dev: false
+
   /archiver@5.3.2:
     resolution: {integrity: sha512-+25nxyyznAXF7Nef3y0EbBeqmGZgeN/BxHX29Rs39djAfaFalmQ89SE6CWyDCHzGL0yt/ycBtNOmGTW0FyGWNw==}
     engines: {node: '>= 10'}
@@ -7244,6 +7367,19 @@ packages:
       readdir-glob: 1.1.3
       tar-stream: 2.2.0
       zip-stream: 4.1.1
+    dev: false
+
+  /archiver@6.0.2:
+    resolution: {integrity: sha512-UQ/2nW7NMl1G+1UnrLypQw1VdT9XZg/ECcKPq7l+STzStrSivFIXIp34D8M5zeNGW5NoOupdYCHv6VySCPNNlw==}
+    engines: {node: '>= 12.0.0'}
+    dependencies:
+      archiver-utils: 4.0.1
+      async: 3.2.4
+      buffer-crc32: 0.2.13
+      readable-stream: 3.6.2
+      readdir-glob: 1.1.3
+      tar-stream: 3.1.6
+      zip-stream: 5.0.2
     dev: false
 
   /archy@1.0.0:
@@ -7316,7 +7452,7 @@ packages:
   /array-buffer-byte-length@1.0.0:
     resolution: {integrity: sha512-LPuwb2P+NrQw3XhxGc36+XSvuBPopovXYTR9Ew++Du9Yb/bx5AzBfrIsBoj0EZUifjQU+sHL21sseZ3jerWO/A==}
     dependencies:
-      call-bind: 1.0.5
+      call-bind: 1.0.7
       is-array-buffer: 3.0.2
 
   /array-buffer-byte-length@1.0.1:
@@ -7443,10 +7579,10 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       array-buffer-byte-length: 1.0.0
-      call-bind: 1.0.5
+      call-bind: 1.0.7
       define-properties: 1.2.1
       es-abstract: 1.22.3
-      get-intrinsic: 1.2.2
+      get-intrinsic: 1.2.4
       is-array-buffer: 3.0.2
       is-shared-array-buffer: 1.0.2
 
@@ -7869,7 +8005,6 @@ packages:
     resolution: {integrity: sha512-fpWrvyVHEKyeEvbKZTVOeZF3VSKKWtJxFIxX/jaVPf+cLbGUSitjb49pHLqPV2BUNNZ0LcoeEGfE/YCpyDYHIw==}
     requiresBuild: true
     dev: false
-    optional: true
 
   /babel-core@7.0.0-bridge.0(@babel/core@7.24.4):
     resolution: {integrity: sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==}
@@ -8475,7 +8610,10 @@ packages:
     peerDependencies:
       constructs: ^10.0.25
     dependencies:
+      archiver: 6.0.2
       constructs: 10.1.167
+      json-stable-stringify: 1.1.1
+      semver: 7.6.0
     dev: false
     bundledDependencies:
       - archiver
@@ -8487,7 +8625,10 @@ packages:
     peerDependencies:
       constructs: ^10.0.25
     dependencies:
+      archiver: 6.0.2
       constructs: 10.3.0
+      json-stable-stringify: 1.1.1
+      semver: 7.6.0
     dev: false
     bundledDependencies:
       - archiver
@@ -9009,6 +9150,16 @@ packages:
       readable-stream: 3.6.2
     dev: false
 
+  /compress-commons@5.0.3:
+    resolution: {integrity: sha512-/UIcLWvwAQyVibgpQDPtfNM3SvqN7G9elAPAV7GM0L53EbNWwWiCsWtK8Fwed/APEbptPHXs5PuW+y8Bq8lFTA==}
+    engines: {node: '>= 12.0.0'}
+    dependencies:
+      crc-32: 1.2.2
+      crc32-stream: 5.0.1
+      normalize-path: 3.0.0
+      readable-stream: 3.6.2
+    dev: false
+
   /compressible@2.0.18:
     resolution: {integrity: sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==}
     engines: {node: '>= 0.6'}
@@ -9162,6 +9313,14 @@ packages:
   /crc32-stream@4.0.3:
     resolution: {integrity: sha512-NT7w2JVU7DFroFdYkeq8cywxrgjPHWkdX1wjpRQXPX5Asews3tA+Ght6lddQO5Mkumffp3X7GEqku3epj2toIw==}
     engines: {node: '>= 10'}
+    dependencies:
+      crc-32: 1.2.2
+      readable-stream: 3.6.2
+    dev: false
+
+  /crc32-stream@5.0.1:
+    resolution: {integrity: sha512-lO1dFui+CEUh/ztYIpgpKItKW9Bb4NWakCRJrnqAbFIYD+OZAwb2VfD5T5eXMw2FNcsDHkQcNl/Wh3iVXYwU6g==}
+    engines: {node: '>= 12.0.0'}
     dependencies:
       crc-32: 1.2.2
       readable-stream: 3.6.2
@@ -9509,7 +9668,7 @@ packages:
     resolution: {integrity: sha512-E7uGkTzkk1d0ByLeSc6ZsFS79Axg+m1P/VsgYsxHgiuc3tFSj+MjMIwe90FC4lOAZzNBdY7kkO2P2wKdsQ1vgQ==}
     engines: {node: '>= 0.4'}
     dependencies:
-      get-intrinsic: 1.2.2
+      get-intrinsic: 1.2.4
       gopd: 1.0.1
       has-property-descriptors: 1.0.1
 
@@ -9782,7 +9941,7 @@ packages:
     dependencies:
       semver: 7.6.0
       shelljs: 0.8.5
-      typescript: 5.5.0-dev.20240516
+      typescript: 5.5.0-dev.20240517
     dev: false
 
   /dset@3.1.3:
@@ -9905,7 +10064,7 @@ packages:
       array-buffer-byte-length: 1.0.0
       arraybuffer.prototype.slice: 1.0.2
       available-typed-arrays: 1.0.5
-      call-bind: 1.0.5
+      call-bind: 1.0.7
       es-set-tostringtag: 2.0.2
       es-to-primitive: 1.2.1
       function.prototype.name: 1.1.6
@@ -10006,7 +10165,7 @@ packages:
   /es-get-iterator@1.1.3:
     resolution: {integrity: sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==}
     dependencies:
-      call-bind: 1.0.5
+      call-bind: 1.0.7
       get-intrinsic: 1.2.2
       has-symbols: 1.0.3
       is-arguments: 1.1.1
@@ -10054,7 +10213,7 @@ packages:
     resolution: {integrity: sha512-BuDyupZt65P9D2D2vA/zqcI3G5xRsklm5N3xCwuiy+/vKy8i0ifdsQP1sLgO4tZDSCaQUSnmC48khknGMV3D2Q==}
     engines: {node: '>= 0.4'}
     dependencies:
-      get-intrinsic: 1.2.2
+      get-intrinsic: 1.2.4
       has-tostringtag: 1.0.0
       hasown: 2.0.0
 
@@ -11142,7 +11301,7 @@ packages:
     resolution: {integrity: sha512-Z5kx79swU5P27WEayXM1tBi5Ze/lbIyiNgU3qyXUOf9b2rgXYyF9Dy9Cx+IQv/Lc8WCG6L82zwUPpSS9hGehIg==}
     engines: {node: '>= 0.4'}
     dependencies:
-      call-bind: 1.0.5
+      call-bind: 1.0.7
       define-properties: 1.2.1
       es-abstract: 1.22.3
       functions-have-names: 1.2.3
@@ -11236,8 +11395,8 @@ packages:
     resolution: {integrity: sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==}
     engines: {node: '>= 0.4'}
     dependencies:
-      call-bind: 1.0.5
-      get-intrinsic: 1.2.2
+      call-bind: 1.0.7
+      get-intrinsic: 1.2.4
 
   /get-symbol-description@1.0.2:
     resolution: {integrity: sha512-g0QYk1dZBxGwk+Ngc+ltRH2IBp2f7zBkBMBJZCDerh6EhlhSR6+9irMCuT/09zD6qkarHUSn529sK/yL4S27mg==}
@@ -11398,6 +11557,17 @@ packages:
       once: 1.4.0
       path-is-absolute: 1.0.1
 
+  /glob@8.1.0:
+    resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      fs.realpath: 1.0.0
+      inflight: 1.0.6
+      inherits: 2.0.4
+      minimatch: 5.1.6
+      once: 1.4.0
+    dev: false
+
   /global-modules@0.2.3:
     resolution: {integrity: sha512-JeXuCbvYzYXcwE6acL9V2bAOeSIGl4dD+iwLY9iUx2VBJJ80R18HCn+JCwHM9Oegdfya3lEkGCdaRkSyc10hDA==}
     engines: {node: '>=0.10.0'}
@@ -11481,7 +11651,7 @@ packages:
   /gopd@1.0.1:
     resolution: {integrity: sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==}
     dependencies:
-      get-intrinsic: 1.2.2
+      get-intrinsic: 1.2.4
 
   /graceful-fs@4.2.10:
     resolution: {integrity: sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==}
@@ -11719,7 +11889,7 @@ packages:
   /has-property-descriptors@1.0.1:
     resolution: {integrity: sha512-VsX8eaIewvas0xnvinAe9bw4WfIeODpGYikiWYLH+dma0Jw6KHYqWiWfhQlgOVK8D6PvjubK5Uc4P0iIhIcNVg==}
     dependencies:
-      get-intrinsic: 1.2.2
+      get-intrinsic: 1.2.4
 
   /has-property-descriptors@1.0.2:
     resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
@@ -12253,7 +12423,7 @@ packages:
     resolution: {integrity: sha512-Y+R5hJrzs52QCG2laLn4udYVnxsfny9CpOhNhUvk/SSSVyF6T27FzRbF0sroPidSu3X8oEAkOn2K804mjpt6UQ==}
     engines: {node: '>= 0.4'}
     dependencies:
-      get-intrinsic: 1.2.2
+      get-intrinsic: 1.2.4
       has: 1.0.3
       side-channel: 1.0.4
 
@@ -12326,13 +12496,13 @@ packages:
     resolution: {integrity: sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==}
     engines: {node: '>= 0.4'}
     dependencies:
-      call-bind: 1.0.5
+      call-bind: 1.0.7
       has-tostringtag: 1.0.0
 
   /is-array-buffer@3.0.2:
     resolution: {integrity: sha512-y+FyyR/w8vfIRq4eQcM1EYgSTnmHXPqaF+IgzgraytCFq5Xh8lllDVmAZolPJiZttZLeFSINPYMaEJ7/vWUa1w==}
     dependencies:
-      call-bind: 1.0.5
+      call-bind: 1.0.7
       get-intrinsic: 1.2.2
       is-typed-array: 1.1.12
 
@@ -12381,7 +12551,7 @@ packages:
     resolution: {integrity: sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==}
     engines: {node: '>= 0.4'}
     dependencies:
-      call-bind: 1.0.5
+      call-bind: 1.0.7
       has-tostringtag: 1.0.0
 
   /is-buffer@1.1.6:
@@ -12637,7 +12807,7 @@ packages:
     resolution: {integrity: sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==}
     engines: {node: '>= 0.4'}
     dependencies:
-      call-bind: 1.0.5
+      call-bind: 1.0.7
       has-tostringtag: 1.0.0
 
   /is-relative@1.0.0:
@@ -12653,7 +12823,7 @@ packages:
   /is-shared-array-buffer@1.0.2:
     resolution: {integrity: sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==}
     dependencies:
-      call-bind: 1.0.5
+      call-bind: 1.0.7
 
   /is-shared-array-buffer@1.0.3:
     resolution: {integrity: sha512-nA2hv5XIhLR3uVzDDfCIknerhx8XUKnstuOERPNNIinXG7v9u+ohXF67vxm4TPTEPU6lm61ZkwP3c9PCB97rhg==}
@@ -12743,13 +12913,13 @@ packages:
   /is-weakref@1.0.2:
     resolution: {integrity: sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==}
     dependencies:
-      call-bind: 1.0.5
+      call-bind: 1.0.7
 
   /is-weakset@2.0.2:
     resolution: {integrity: sha512-t2yVvttHkQktwnNNmBQ98AhENLdPUTDTE21uPqAQ0ARwQfGeQKRVS0NNurH7bTf7RrvcVn1OOge45CnBeHCSmg==}
     dependencies:
-      call-bind: 1.0.5
-      get-intrinsic: 1.2.2
+      call-bind: 1.0.7
+      get-intrinsic: 1.2.4
 
   /is-windows@0.2.0:
     resolution: {integrity: sha512-n67eJYmXbniZB7RF4I/FTjK1s6RPOCTxhYrVYLRaCt3lF0mpWZPKr3T2LSZAqyjQsxR2qMmGYXXzK0YWwcPM1Q==}
@@ -13699,6 +13869,16 @@ packages:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
     dev: true
 
+  /json-stable-stringify@1.1.1:
+    resolution: {integrity: sha512-SU/971Kt5qVQfJpyDveVhQ/vya+5hvrjClFOcr8c0Fq5aODJjMwutrOfCU+eCnVD5gpx1Q3fEqkyom77zH1iIg==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind: 1.0.7
+      isarray: 2.0.5
+      jsonify: 0.0.1
+      object-keys: 1.1.1
+    dev: false
+
   /json-stringify-safe@5.0.1:
     resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
     dev: false
@@ -13726,6 +13906,10 @@ packages:
       universalify: 2.0.0
     optionalDependencies:
       graceful-fs: 4.2.11
+
+  /jsonify@0.0.1:
+    resolution: {integrity: sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==}
+    dev: false
 
   /jsx-ast-utils@3.3.5:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
@@ -15182,7 +15366,7 @@ packages:
     resolution: {integrity: sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==}
     engines: {node: '>= 0.4'}
     dependencies:
-      call-bind: 1.0.5
+      call-bind: 1.0.7
       define-properties: 1.2.1
 
   /object-keys@1.1.1:
@@ -15200,7 +15384,7 @@ packages:
     resolution: {integrity: sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==}
     engines: {node: '>= 0.4'}
     dependencies:
-      call-bind: 1.0.5
+      call-bind: 1.0.7
       define-properties: 1.2.1
       has-symbols: 1.0.3
       object-keys: 1.1.1
@@ -16633,7 +16817,7 @@ packages:
     resolution: {integrity: sha512-sy6TXMN+hnP/wMy+ISxg3krXx7BAtWVO4UouuCN/ziM9UEne0euamVNafDfvC83bRNr95y0V5iijeDQFUNpvrg==}
     engines: {node: '>= 0.4'}
     dependencies:
-      call-bind: 1.0.5
+      call-bind: 1.0.7
       define-properties: 1.2.1
       set-function-name: 2.0.1
 
@@ -17108,8 +17292,8 @@ packages:
     resolution: {integrity: sha512-ZdQ0Jeb9Ofti4hbt5lX3T2JcAamT9hfzYU1MNB+z/jaEbB6wfFfPIR/zEORmZqobkCCJhSjodobH6WHNmJ97dg==}
     engines: {node: '>=0.4'}
     dependencies:
-      call-bind: 1.0.5
-      get-intrinsic: 1.2.2
+      call-bind: 1.0.7
+      get-intrinsic: 1.2.4
       has-symbols: 1.0.3
       isarray: 2.0.5
 
@@ -17141,8 +17325,8 @@ packages:
     resolution: {integrity: sha512-83S9w6eFq12BBIJYvjMux6/dkirb8+4zJRA9cxNBVb7Wq5fJBW+Xze48WqR8pxua7bDuAaaAxtVVd4Idjp1dBQ==}
     engines: {node: '>= 0.4'}
     dependencies:
-      call-bind: 1.0.5
-      get-intrinsic: 1.2.2
+      call-bind: 1.0.7
+      get-intrinsic: 1.2.4
       is-regex: 1.1.4
 
   /safe-regex-test@1.0.3:
@@ -17393,7 +17577,7 @@ packages:
     dependencies:
       define-data-property: 1.1.1
       function-bind: 1.1.2
-      get-intrinsic: 1.2.2
+      get-intrinsic: 1.2.4
       gopd: 1.0.1
       has-property-descriptors: 1.0.1
 
@@ -17500,7 +17684,7 @@ packages:
   /side-channel@1.0.4:
     resolution: {integrity: sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==}
     dependencies:
-      call-bind: 1.0.5
+      call-bind: 1.0.7
       get-intrinsic: 1.2.2
       object-inspect: 1.13.1
 
@@ -17830,11 +18014,11 @@ packages:
     resolution: {integrity: sha512-siT1RiqlfQnGqgT/YzXVUNsom9S0H1OX+dpdGN1xkyYATo4I6sep5NmsRD/40s3IIOvlCq6akxkqG82urIZW1w==}
     dev: true
 
-  /storybook@7.6.17:
-    resolution: {integrity: sha512-8+EIo91bwmeFWPg1eysrxXlhIYv3OsXrznTr4+4Eq0NikqAoq6oBhtlN5K2RGS2lBVF537eN+9jTCNbR+WrzDA==}
+  /storybook@7.6.19:
+    resolution: {integrity: sha512-xWD1C4vD/4KMffCrBBrUpsLUO/9uNpm8BVW8+Vcb30gkQDfficZ0oziWkmLexpT53VSioa24iazGXMwBqllYjQ==}
     hasBin: true
     dependencies:
-      '@storybook/cli': 7.6.17
+      '@storybook/cli': 7.6.19
     transitivePeerDependencies:
       - bufferutil
       - encoding
@@ -17997,7 +18181,7 @@ packages:
     resolution: {integrity: sha512-lfjY4HcixfQXOfaqCvcBuOIapyaroTXhbkfJN3gcB1OtyupngWK4sEET9Knd0cXd28kTUqu/kHoV4HKSJdnjiQ==}
     engines: {node: '>= 0.4'}
     dependencies:
-      call-bind: 1.0.5
+      call-bind: 1.0.7
       define-properties: 1.2.1
       es-abstract: 1.22.3
 
@@ -18013,7 +18197,7 @@ packages:
   /string.prototype.trimend@1.0.7:
     resolution: {integrity: sha512-Ni79DqeB72ZFq1uH/L6zJ+DKZTkOtPIHovb3YZHQViE+HDouuU4mBrLOLDn5Dde3RF8qw5qVETEjhu9locMLvA==}
     dependencies:
-      call-bind: 1.0.5
+      call-bind: 1.0.7
       define-properties: 1.2.1
       es-abstract: 1.22.3
 
@@ -18027,7 +18211,7 @@ packages:
   /string.prototype.trimstart@1.0.7:
     resolution: {integrity: sha512-NGhtDFu3jCEm7B4Fy0DpLewdJQOZcQ0rGbwQ/+stjnrp2i+rlKeCvos9hOIeCmqwratM47OBxY7uFZzjxHXmrg==}
     dependencies:
-      call-bind: 1.0.5
+      call-bind: 1.0.7
       define-properties: 1.2.1
       es-abstract: 1.22.3
 
@@ -18234,7 +18418,6 @@ packages:
       fast-fifo: 1.3.2
       streamx: 2.15.1
     dev: false
-    optional: true
 
   /tar@6.2.0:
     resolution: {integrity: sha512-/Wo7DcT0u5HUV486xg675HtjNd3BXZ6xDbzsCUZPt5iw8bTQ63bP0Raut3mvro9u+CUyq7YQd8Cx55fsZXxqLQ==}
@@ -18796,8 +18979,8 @@ packages:
     resolution: {integrity: sha512-Y8KTSIglk9OZEr8zywiIHG/kmQ7KWyjseXs1CbSo8vC42w7hg2HgYTxSWwP0+is7bWDc1H+Fo026CpHFwm8tkw==}
     engines: {node: '>= 0.4'}
     dependencies:
-      call-bind: 1.0.5
-      get-intrinsic: 1.2.2
+      call-bind: 1.0.7
+      get-intrinsic: 1.2.4
       is-typed-array: 1.1.12
 
   /typed-array-buffer@1.0.2:
@@ -18812,7 +18995,7 @@ packages:
     resolution: {integrity: sha512-Or/+kvLxNpeQ9DtSydonMxCx+9ZXOswtwJn17SNLvhptaXYDJvkFFP5zbfU/uLmvnBJlI4yrnXRxpdWH/M5tNA==}
     engines: {node: '>= 0.4'}
     dependencies:
-      call-bind: 1.0.5
+      call-bind: 1.0.7
       for-each: 0.3.3
       has-proto: 1.0.1
       is-typed-array: 1.1.12
@@ -18832,7 +19015,7 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       available-typed-arrays: 1.0.5
-      call-bind: 1.0.5
+      call-bind: 1.0.7
       for-each: 0.3.3
       has-proto: 1.0.1
       is-typed-array: 1.1.12
@@ -18851,7 +19034,7 @@ packages:
   /typed-array-length@1.0.4:
     resolution: {integrity: sha512-KjZypGq+I/H7HI5HlOoGHkWUUGq+Q0TPhQurLbyrVrvnKTBgzLhIJ7j6J/XTQOi0d1RjyZ0wdas8bKs2p0x3Ng==}
     dependencies:
-      call-bind: 1.0.5
+      call-bind: 1.0.7
       for-each: 0.3.3
       is-typed-array: 1.1.12
 
@@ -18906,8 +19089,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  /typescript@5.5.0-dev.20240516:
-    resolution: {integrity: sha512-MNzi4B6WADePeOrxzfVArpyIW0P3ihAqAU4+l2GiBRbz3M+oIUEJCiLE/o5VMLoUAyPu9mCSshsMcsbpPu9wzQ==}
+  /typescript@5.5.0-dev.20240517:
+    resolution: {integrity: sha512-xpneJT+1seecSblhCb/6RarVhdJzwhEWl0iY26aJxOvtHUiI2tFOajGJALNTy++pwG69iEOeQAR9ax7cKwT9IQ==}
     engines: {node: '>=14.17'}
     hasBin: true
     dev: false
@@ -18934,7 +19117,7 @@ packages:
   /unbox-primitive@1.0.2:
     resolution: {integrity: sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==}
     dependencies:
-      call-bind: 1.0.5
+      call-bind: 1.0.7
       has-bigints: 1.0.2
       has-symbols: 1.0.3
       which-boxed-primitive: 1.0.2
@@ -20181,7 +20364,7 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       available-typed-arrays: 1.0.5
-      call-bind: 1.0.5
+      call-bind: 1.0.7
       for-each: 0.3.3
       gopd: 1.0.1
       has-tostringtag: 1.0.0
@@ -20549,6 +20732,15 @@ packages:
     dependencies:
       archiver-utils: 3.0.4
       compress-commons: 4.1.2
+      readable-stream: 3.6.2
+    dev: false
+
+  /zip-stream@5.0.2:
+    resolution: {integrity: sha512-LfOdrUvPB8ZoXtvOBz6DlNClfvi//b5d56mSWyJi7XbH/HfhOHfUhOqxhT/rUiR7yiktlunqRo+jY6y/cWC/5g==}
+    engines: {node: '>= 12.0.0'}
+    dependencies:
+      archiver-utils: 4.0.1
+      compress-commons: 5.0.3
       readable-stream: 3.6.2
     dev: false
 

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "composite": true,
+    "declaration": true,
+    "esModuleInterop": true,
+    "isolatedModules": false,
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "noErrorTruncation": true,
+    "noImplicitAny": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "ESNext",
+    "resolveJsonModule": true
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "moduleResolution": "node",
     "noErrorTruncation": true,
     "noImplicitAny": true,
+    "skipLibCheck": true,
     "strict": true,
     "target": "ESNext",
     "resolveJsonModule": true,
@@ -20,7 +21,22 @@
   ],
   "references": [
     {
+      "path": "./apps/cli/tsconfig.json"
+    },
+    {
+      "path": "./apps/doj-demo/tsconfig.json"
+    },
+    {
+      "path": "./apps/rest-api/tsconfig.json"
+    },
+    {
+      "path": "./apps/spotlight/tsconfig.json"
+    },
+    {
       "path": "./packages/common/tsconfig.json"
+    },
+    {
+      "path": "./packages/dependency-graph/tsconfig.json"
     },
     {
       "path": "./packages/design/tsconfig.json"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,51 +1,14 @@
 {
-  "compilerOptions": {
-    "allowSyntheticDefaultImports": true,
-    "composite": true,
-    "declaration": true,
-    "esModuleInterop": true,
-    "isolatedModules": false,
-    "module": "ESNext",
-    "moduleResolution": "node",
-    "noErrorTruncation": true,
-    "noImplicitAny": true,
-    "skipLibCheck": true,
-    "strict": true,
-    "target": "ESNext",
-    "resolveJsonModule": true,
-  },
-  "exclude": [
-    "node_modules",
-    "**/*/lib",
-    "**/*/dist"
-  ],
+  "extends": "./tsconfig.base.json",
+  "files": [],
   "references": [
-    {
-      "path": "./apps/cli/tsconfig.json"
-    },
-    {
-      "path": "./apps/doj-demo/tsconfig.json"
-    },
-    {
-      "path": "./apps/rest-api/tsconfig.json"
-    },
-    {
-      "path": "./apps/spotlight/tsconfig.json"
-    },
-    {
-      "path": "./packages/common/tsconfig.json"
-    },
-    {
-      "path": "./packages/dependency-graph/tsconfig.json"
-    },
-    {
-      "path": "./packages/design/tsconfig.json"
-    },
-    {
-      "path": "./packages/form-service/tsconfig.json"
-    },
-    {
-      "path": "./packages/forms/tsconfig.json"
-    }
+    { "path": "./apps/cli" },
+    { "path": "./apps/rest-api" },
+    { "path": "./infra" },
+    { "path": "./packages/common" },
+    { "path": "./packages/dependency-graph" },
+    { "path": "./packages/design" },
+    { "path": "./packages/form-service" },
+    { "path": "./packages/forms" }
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     { "path": "./infra" },
     { "path": "./packages/common" },
     { "path": "./packages/dependency-graph" },
-    { "path": "./packages/design" },
+    { "path": "./packages/design/tsconfig.build.json" },
     { "path": "./packages/form-service" },
     { "path": "./packages/forms" }
   ]


### PR DESCRIPTION
We haven't been doing automated type-checking, and as a result, a lot of errors have accumulated. This branch:

- Adds a `typecheck` npm script
- Cleans up type errors
- Adds `typecheck` to the `run-tests.yml` Github Actions workflow

There aren't any behavior changes in this PR.
