### PR TITLE
Fix bug with input field not populating previous and default values on the FormEdit UI

### DIFF
--- a/packages/design/src/FormManager/FormEdit/components/CheckboxPatternEdit.test.tsx
+++ b/packages/design/src/FormManager/FormEdit/components/CheckboxPatternEdit.test.tsx
@@ -1,11 +1,11 @@
 /**
  * @vitest-environment jsdom
  */
-import { expect, it } from 'vitest'
+import { expect, it } from 'vitest';
 
 it('Is a placeholder test for now', () => {
   expect(true).to.be.true;
-})
+});
 // import { describeStories } from '../../../test-helper';
 // import meta, * as stories from './CheckboxPatternEdit.stories';
 

--- a/packages/design/src/FormManager/FormEdit/components/InputPatternEdit.tsx
+++ b/packages/design/src/FormManager/FormEdit/components/InputPatternEdit.tsx
@@ -42,6 +42,10 @@ const EditComponent = ({ patternId }: { patternId: PatternId }) => {
   const label = getFieldState('label');
   const maxLength = getFieldState('maxLength');
 
+  const maxLengthAttributes = pattern.data.maxLength > 0 ? {
+    defaultValue: pattern.data.maxLength
+  } : {};
+
   return (
     <div className="grid-row grid-gap-1">
       <div className="tablet:grid-col-6 mobile-lg:grid-col-12">
@@ -68,7 +72,7 @@ const EditComponent = ({ patternId }: { patternId: PatternId }) => {
           ></input>
         </label>
       </div>
-      <div className="tablet:grid-col-6 mobile-lg:grid-col-12">
+      <div className="tablet:grid-col-6 mobile-lg:grid-col-12 ohio">
         <label
           className={classnames('usa-label', {
             'usa-label--error': initial.error,
@@ -85,6 +89,7 @@ const EditComponent = ({ patternId }: { patternId: PatternId }) => {
             className="usa-input bg-primary-lighter text-bold"
             id={fieldId('initial')}
             type="text"
+            defaultValue={pattern.data.initial}
             {...register('initial')}
           ></input>
         </label>
@@ -105,6 +110,7 @@ const EditComponent = ({ patternId }: { patternId: PatternId }) => {
           <input
             className="usa-input bg-primary-lighter text-bold"
             id={fieldId('maxLength')}
+            {...maxLengthAttributes}
             type="text"
             {...register('maxLength')}
           ></input>

--- a/packages/design/src/FormManager/FormEdit/components/InputPatternEdit.tsx
+++ b/packages/design/src/FormManager/FormEdit/components/InputPatternEdit.tsx
@@ -42,9 +42,12 @@ const EditComponent = ({ patternId }: { patternId: PatternId }) => {
   const label = getFieldState('label');
   const maxLength = getFieldState('maxLength');
 
-  const maxLengthAttributes = pattern.data.maxLength > 0 ? {
-    defaultValue: pattern.data.maxLength
-  } : {};
+  const maxLengthAttributes =
+    pattern.data.maxLength > 0
+      ? {
+          defaultValue: pattern.data.maxLength,
+        }
+      : {};
 
   return (
     <div className="grid-row grid-gap-1">
@@ -119,14 +122,14 @@ const EditComponent = ({ patternId }: { patternId: PatternId }) => {
       <div className="grid-col-12">
         <PatternEditActions>
           <span className="usa-checkbox">
-              <input
-                style={{ display: 'inline-block' }}
-                className="usa-checkbox__input bg-primary-lighter"
-                type="checkbox"
-                id={fieldId('required')}
-                {...register('required')}
-                defaultChecked={pattern.data.required}
-              />
+            <input
+              style={{ display: 'inline-block' }}
+              className="usa-checkbox__input bg-primary-lighter"
+              type="checkbox"
+              id={fieldId('required')}
+              {...register('required')}
+              defaultChecked={pattern.data.required}
+            />
             <label
               style={{ display: 'inline-block' }}
               className="usa-checkbox__label"


### PR DESCRIPTION
Values for max length and initial value were being wiped out in the form edit UI when opened and closed.