### PR TITLE
Filter out patternIds with empty string values.

### DIFF
--- a/packages/forms/src/patterns/page/prompt.ts
+++ b/packages/forms/src/patterns/page/prompt.ts
@@ -13,10 +13,13 @@ export const createPrompt: CreatePrompt<PagePattern> = (
   pattern,
   options
 ) => {
-  const children = pattern.data.patterns.map((patternId: string) => {
-    const childPattern = getPattern(session.form, patternId);
-    return createPromptForPattern(config, session, childPattern, options);
-  });
+  // :TODO: There's an edge case with page saving where it's being saved with an empty string value. Figure out root cause.
+  const children = pattern.data.patterns
+    .filter((patternId: string) => patternId.length > 0)
+    .map((patternId: string) => {
+      const childPattern = getPattern(session.form, patternId);
+      return createPromptForPattern(config, session, childPattern, options);
+    });
   return {
     props: {
       _patternId: pattern.id,


### PR DESCRIPTION
Fixes page title saving error. There were certain situations where the patterns array would have an item with an `""`, causing the `createPromptForPattern` check to fail.