### PR TITLE
Prevent onFocus event from propagating from dnd handles to parent edit components

### DIFF
--- a/packages/design/src/FormManager/FormEdit/components/PreviewSequencePattern/DraggableList.tsx
+++ b/packages/design/src/FormManager/FormEdit/components/PreviewSequencePattern/DraggableList.tsx
@@ -1,4 +1,4 @@
-import React, { Children, useState } from 'react';
+import React, { Children } from 'react';
 import {
   DndContext,
   closestCenter,

--- a/packages/design/src/FormManager/FormEdit/components/PreviewSequencePattern/DraggableList.tsx
+++ b/packages/design/src/FormManager/FormEdit/components/PreviewSequencePattern/DraggableList.tsx
@@ -1,4 +1,4 @@
-import React, { Children } from 'react';
+import React, { Children, useState } from 'react';
 import {
   DndContext,
   closestCenter,
@@ -37,33 +37,40 @@ export const DraggableList: React.FC<DraggableListProps> = ({
   const arrayChildren = Children.toArray(children);
 
   return (
-    <DndContext
-      sensors={sensors}
-      collisionDetection={closestCenter}
-      onDragEnd={event => {
-        const { active, over } = event;
-        if (over === null) {
-          return;
-        }
-        if (active.id !== over.id) {
-          const oldIndex = order.indexOf(active.id);
-          const newIndex = order.indexOf(over.id);
-          const newOrder = arrayMove(order, oldIndex, newIndex);
-          updateOrder(newOrder);
-        }
+    <div
+      onFocus={event => {
+        // Stop onFocus events from bubbling up to parent elements.
+        event.stopPropagation();
       }}
     >
-      <SortableContext items={order} strategy={verticalListSortingStrategy}>
-        {arrayChildren.map((child, index) => {
-          const patternId = order[index];
-          return (
-            <SortableItem key={index} id={patternId}>
-              {child}
-            </SortableItem>
-          );
-        })}
-      </SortableContext>
-    </DndContext>
+      <DndContext
+        sensors={sensors}
+        collisionDetection={closestCenter}
+        onDragEnd={event => {
+          const { active, over } = event;
+          if (over === null) {
+            return;
+          }
+          if (active.id !== over.id) {
+            const oldIndex = order.indexOf(active.id);
+            const newIndex = order.indexOf(over.id);
+            const newOrder = arrayMove(order, oldIndex, newIndex);
+            updateOrder(newOrder);
+          }
+        }}
+      >
+        <SortableContext items={order} strategy={verticalListSortingStrategy}>
+          {arrayChildren.map((child, index) => {
+            const patternId = order[index];
+            return (
+              <SortableItem key={index} id={patternId}>
+                {child}
+              </SortableItem>
+            );
+          })}
+        </SortableContext>
+      </DndContext>
+    </div>
   );
 };
 

--- a/packages/design/src/FormManager/FormEdit/store.ts
+++ b/packages/design/src/FormManager/FormEdit/store.ts
@@ -141,6 +141,9 @@ export const createFormEditSlice =
           [pattern.id]: pattern.data,
         }
       );
+      if (!success) {
+        console.error('Failed to update pattern.', pattern);
+      }
       if (success) {
         set({
           session: mergeSession(state.session, { form: builder.form }),

--- a/packages/forms/src/builder/index.ts
+++ b/packages/forms/src/builder/index.ts
@@ -71,6 +71,7 @@ export class BlueprintBuilder {
       formData
     );
     if (!result.success) {
+      console.error('Error updating pattern', result.error);
       return false;
     }
     this.bp = result.data;


### PR DESCRIPTION
So edit mode isn't inadvertently triggered while reordering via drag, prevent onFocus event from propagating from dnd handles to parent edit components.