### PR TITLE
Comment out radio group outputs

### DIFF
--- a/packages/forms/src/documents/pdf/parsing-api.ts
+++ b/packages/forms/src/documents/pdf/parsing-api.ts
@@ -256,6 +256,7 @@ export const processApiResponse = async (json: any): Promise<ParsedPdf> => {
       );
       if (radioGroupPattern) {
         rootSequence.push(radioGroupPattern.id);
+        /*
         parsedPdf.outputs[radioGroupPattern.id] = {
           type: 'RadioGroup',
           name: element.id,
@@ -269,6 +270,7 @@ export const processApiResponse = async (json: any): Promise<ParsedPdf> => {
           value: '',
           required: true,
         };
+        */
       }
       continue;
     }


### PR DESCRIPTION
To avoid PDF generation errors, comment out radio group outputs, temporarily.
