### PR TITLE
Fix: Loss of focus after drag-and-drop

### DIFF
--- a/packages/design/src/FormManager/FormEdit/components/PreviewSequencePattern/DraggableList.tsx
+++ b/packages/design/src/FormManager/FormEdit/components/PreviewSequencePattern/DraggableList.tsx
@@ -63,7 +63,7 @@ export const DraggableList: React.FC<DraggableListProps> = ({
           {arrayChildren.map((child, index) => {
             const patternId = order[index];
             return (
-              <SortableItem key={index} id={patternId}>
+              <SortableItem key={patternId} id={patternId}>
                 {child}
               </SortableItem>
             );


### PR DESCRIPTION
Key on unique pattern ID rather than child index, so focus isn't lost on an item after reordering.