### PR TITLE
Store Cloud.gov secrets in AWS parameter store

### DIFF
--- a/infra/cdktf.json
+++ b/infra/cdktf.json
@@ -3,7 +3,10 @@
   "app": "npx ts-node src/index.ts",
   "projectId": "9bbe7827-9202-4cf8-8d85-a8241c08ab5c",
   "sendCrashReports": "false",
-  "terraformProviders": ["cloudfoundry-community/cloudfoundry@0.53.1"],
+  "terraformProviders": [
+    "hashicorp/aws@5.54.1",
+    "cloudfoundry-community/cloudfoundry@0.53.1"
+  ],
   "terraformModules": [],
   "context": {
     "excludeStackIdFromLogicalIds": "true",

--- a/infra/package.json
+++ b/infra/package.json
@@ -18,9 +18,8 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
-    "@cdktf/provider-aws": "18.0.1",
-    "cdktf": "^0.20.4",
-    "cdktf-cli": "^0.20.4",
+    "cdktf": "^0.20.7",
+    "cdktf-cli": "^0.20.7",
     "constructs": "^10.3.0"
   },
   "devDependencies": {

--- a/infra/src/lib/app-stack.ts
+++ b/infra/src/lib/app-stack.ts
@@ -1,9 +1,12 @@
 import { App, TerraformStack } from 'cdktf';
 import { Construct } from 'constructs';
+
+import { AwsProvider } from '../../.gen/providers/aws/provider';
 import { CloudfoundryProvider } from '../../.gen/providers/cloudfoundry/provider';
 
 import { withBackend } from './backend';
 import { CloudGovSpace } from './cloud.gov/space';
+import { DataAwsSsmParameter } from '../../.gen/providers/aws/data-aws-ssm-parameter';
 
 export const registerAppStack = (stackPrefix: string) => {
   const app = new App();
@@ -16,18 +19,35 @@ class AppStack extends TerraformStack {
   constructor(scope: Construct, id: string) {
     super(scope, id);
 
-    /*new AwsProvider(this, 'AWS', {
+    new AwsProvider(this, 'AWS', {
       region: 'us-east-2',
-    });*/
+    });
+
+    const cfUsername = new DataAwsSsmParameter(
+      this,
+      `${id}-cloudfoundry-username`,
+      {
+        name: `/${id}/cloudfoundry/username`,
+      }
+    );
+    const cfPassword = new DataAwsSsmParameter(
+      this,
+      `${id}-cloudfoundry-password`,
+      {
+        name: `/${id}/cloudfoundry/password`,
+      }
+    );
 
     new CloudfoundryProvider(this, 'cloud-gov', {
       apiUrl: 'https://api.fr.cloud.gov',
       appLogsMax: 30,
-      ssoPasscode: '',
+      user: cfUsername.value,
+      password: cfPassword.value,
     });
 
-    //new Docassemble(this, `${id}-docassemble`);
     new CloudGovSpace(this, id);
+
+    //new Docassemble(this, `${id}-docassemble`);
     //new FormService(this, `${id}-rest-api`);
   }
 }


### PR DESCRIPTION
Acquire Cloud.gov secrets from AWS parameter store via a Terraform data lookup.

Context: this allows us to easily have separate service accounts for each deployment environment, and rotate credentials.
