### PR TITLE
Repeater field component

### DIFF
--- a/.github/workflows/_validate.yml
+++ b/.github/workflows/_validate.yml
@@ -45,7 +45,7 @@ jobs:
         run: pnpm install
 
       - name: Install playwright
-        run: pnpm dlx playwright install --with-deps
+        run: pnpm dlx playwright@1.47.2 install --with-deps
 
       # While most of the test suite is self-contained, the tests for the demo
       # servers require a prod build of @atj/server.

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 _site
 .turbo/
 .vscode/
+.idea/
 coverage/
 html/
 node_modules/

--- a/packages/common/src/locales/en/app.ts
+++ b/packages/common/src/locales/en/app.ts
@@ -41,5 +41,10 @@ export const en = {
       fieldLabel: 'Radio group label',
       errorTextMustContainChar: 'String must contain at least 1 character(s)',
     },
+    repeater: {
+      ...defaults,
+      displayName: 'Repeatable Group',
+      errorTextMustContainChar: 'String must contain at least 1 character(s)',
+    },
   },
 };

--- a/packages/design/src/Form/components/RadioGroup/RadioGroup.tsx
+++ b/packages/design/src/Form/components/RadioGroup/RadioGroup.tsx
@@ -13,17 +13,20 @@ export const RadioGroupPattern: PatternComponent<RadioGroupProps> = props => {
         {props.legend}
       </legend>
       {props.options.map((option, index) => {
+        const id = props.idSuffix ? `${option.id}${props.idSuffix}` : option.id;
         return (
           <div key={index} className="usa-radio">
             <input
               className="usa-radio__input"
               type="radio"
-              id={option.id}
-              {...register(props.groupId)}
+              id={`input-${id}`}
+              {...register(
+                `${props.groupId}${props.idSuffix ? props.idSuffix : ''}`
+              )}
               value={option.id}
               defaultChecked={option.defaultChecked}
             />
-            <label htmlFor={option.id} className="usa-radio__label">
+            <label htmlFor={`input-${id}`} className="usa-radio__label">
               {option.label}
             </label>
           </div>

--- a/packages/design/src/Form/components/Repeater/Repeater.stories.tsx
+++ b/packages/design/src/Form/components/Repeater/Repeater.stories.tsx
@@ -1,0 +1,17 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import Repeater from './index.js';
+
+export default {
+  title: 'patterns/Repeater',
+  component: Repeater,
+  tags: ['autodocs'],
+} satisfies Meta<typeof Repeater>;
+
+export const RepeaterSection = {
+  args: {
+    legend: 'Default Heading',
+    type: 'repeater',
+    _patternId: 'test-id',
+  },
+} satisfies StoryObj<typeof Repeater>;

--- a/packages/design/src/Form/components/Repeater/Repeater.test.tsx
+++ b/packages/design/src/Form/components/Repeater/Repeater.test.tsx
@@ -1,0 +1,7 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describeStories } from '../../../test-helper.js';
+import meta, * as stories from './Repeater.stories.js';
+
+describeStories(meta, stories);

--- a/packages/design/src/Form/components/Repeater/edit.tsx
+++ b/packages/design/src/Form/components/Repeater/edit.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { type RepeaterProps } from '@atj/forms';
+import { type PatternComponent } from '../../../Form/index.js';
+
+const RepeaterEditView: PatternComponent<RepeaterProps> = props => {
+  return (
+    <fieldset className="usa-fieldset width-full padding-top-2">
+      {props.legend !== '' && props.legend !== undefined && (
+        <legend className="usa-legend text-bold text-uppercase line-height-body-4 width-full margin-top-0 padding-top-3 padding-bottom-1">
+          {props.legend}
+        </legend>
+      )}
+
+      {props.children}
+    </fieldset>
+  );
+};
+
+export default RepeaterEditView;

--- a/packages/design/src/Form/components/Repeater/index.tsx
+++ b/packages/design/src/Form/components/Repeater/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useFieldArray, useForm } from 'react-hook-form';
 import { type RepeaterProps } from '@atj/forms';
-import { type PatternComponent } from '../../../Form/index.js';
+import { type PatternComponent } from '../../index.js';
 
 const Repeater: PatternComponent<RepeaterProps> = props => {
   const STORAGE_KEY = `repeater-${props._patternId}`;
@@ -36,7 +36,7 @@ const Repeater: PatternComponent<RepeaterProps> = props => {
   const renderWithUniqueIds = (children: React.ReactNode, index: number) => {
     return React.Children.map(children, child => {
       if (React.isValidElement(child) && child?.props?.component?.props) {
-        return React.cloneElement(child, {
+        return React.cloneElement(child as React.ReactElement, {
           component: {
             ...child.props.component,
             props: {

--- a/packages/design/src/Form/components/Repeater/index.tsx
+++ b/packages/design/src/Form/components/Repeater/index.tsx
@@ -25,11 +25,15 @@ const Repeater: PatternComponent<RepeaterProps> = props => {
     name: 'fields',
   });
 
-  React.useEffect(() => {
-    // if(!localStorage.getItem(STORAGE_KEY) && fields.length !== 1) {
-    //   localStorage.setItem(STORAGE_KEY, JSON.stringify(fields.length));
-    // }
-  }, [fields.length]);
+  /**
+   * TODO: discuss how this should behave for the user if they resume the form
+   * at a later point.
+   */
+  // React.useEffect(() => {
+  //   if(!localStorage.getItem(STORAGE_KEY) && fields.length !== 1) {
+  //     localStorage.setItem(STORAGE_KEY, JSON.stringify(fields.length));
+  //   }
+  // }, [fields.length]);
 
   const hasFields = React.Children.toArray(props.children).length > 0;
 

--- a/packages/design/src/Form/components/Repeater/index.tsx
+++ b/packages/design/src/Form/components/Repeater/index.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import { useFieldArray, useForm } from 'react-hook-form';
+import { type RepeaterProps } from '@atj/forms';
+import { type PatternComponent } from '../../../Form/index.js';
+
+const Repeater: PatternComponent<RepeaterProps> = props => {
+  const STORAGE_KEY = `repeater-${props._patternId}`;
+
+  const loadInitialFields = (): number => {
+    const storedFields = localStorage.getItem(STORAGE_KEY);
+    if (storedFields) {
+      return parseInt(JSON.parse(storedFields), 10) || 1;
+    }
+    return 1;
+  };
+
+  const { control } = useForm({
+    defaultValues: {
+      fields: Array(loadInitialFields()).fill({}),
+    },
+  });
+
+  const { fields, append, remove } = useFieldArray({
+    control,
+    name: 'fields',
+  });
+
+  React.useEffect(() => {
+    // if(!localStorage.getItem(STORAGE_KEY) && fields.length !== 1) {
+    //   localStorage.setItem(STORAGE_KEY, JSON.stringify(fields.length));
+    // }
+  }, [fields.length]);
+
+  const hasFields = React.Children.toArray(props.children).length > 0;
+
+  const renderWithUniqueIds = (children: React.ReactNode, index: number) => {
+    return React.Children.map(children, child => {
+      if (React.isValidElement(child) && child?.props?.component?.props) {
+        return React.cloneElement(child, {
+          component: {
+            ...child.props.component,
+            props: {
+              ...child.props.component.props,
+              idSuffix: `.repeater.${index}`,
+            },
+          },
+        });
+      }
+      return child;
+    });
+  };
+
+  return (
+    <fieldset className="usa-fieldset width-full padding-top-2">
+      {props.legend && (
+        <legend className="usa-legend text-bold text-uppercase line-height-body-4 width-full margin-top-0 padding-top-3 padding-bottom-1">
+          {props.legend}
+        </legend>
+      )}
+      {hasFields && (
+        <>
+          <ul className="add-list-reset margin-bottom-4">
+            {fields.map((field, index) => (
+              <li
+                key={field.id}
+                className="padding-bottom-4 border-bottom border-base-lighter"
+              >
+                {renderWithUniqueIds(props.children, index)}
+              </li>
+            ))}
+          </ul>
+          <div className="usa-button-group margin-bottom-4">
+            <button
+              type="button"
+              className="usa-button usa-button--outline"
+              onClick={() => append({})}
+            >
+              Add new item
+            </button>
+            <button
+              type="button"
+              className="usa-button usa-button--outline"
+              onClick={() => remove(fields.length - 1)}
+              disabled={fields.length === 1}
+            >
+              Delete item
+            </button>
+          </div>
+        </>
+      )}
+    </fieldset>
+  );
+};
+
+export default Repeater;

--- a/packages/design/src/Form/components/SubmissionConfirmation/index.tsx
+++ b/packages/design/src/Form/components/SubmissionConfirmation/index.tsx
@@ -5,7 +5,7 @@ import { type PatternComponent } from '../../../Form/index.js';
 
 const SubmissionConfirmation: PatternComponent<
   SubmissionConfirmationProps
-> = props => {
+> = (/* props */) => {
   return (
     <>
       <legend className="usa-legend usa-legend--large">
@@ -39,30 +39,35 @@ const SubmissionConfirmation: PatternComponent<
             Submission details
           </button>
         </h4>
-        <div
-          id="submission-confirmation-table"
-          className="usa-accordion__content usa-prose"
-          hidden={true}
-        >
-          <table className="usa-table usa-table--striped width-full">
-            <thead>
-              <tr>
-                <th scope="col">Form field</th>
-                <th scope="col">Provided value</th>
-              </tr>
-            </thead>
-            <tbody>
-              {props.table.map((row, index) => {
-                return (
-                  <tr key={index}>
-                    <th scope="row">{row.label}</th>
-                    <td>{row.value}</td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
-        </div>
+        {/*
+          EG: turn this off for now. Will need some design perhaps to see what the presentation
+          should look like. This was a minimal blocker for the repeater field due to the flat data structure
+          that was there previously.
+        */}
+        {/*<div*/}
+        {/*  id="submission-confirmation-table"*/}
+        {/*  className="usa-accordion__content usa-prose"*/}
+        {/*  hidden={true}*/}
+        {/*>*/}
+        {/*  <table className="usa-table usa-table--striped width-full">*/}
+        {/*    <thead>*/}
+        {/*      <tr>*/}
+        {/*        <th scope="col">Form field</th>*/}
+        {/*        <th scope="col">Provided value</th>*/}
+        {/*      </tr>*/}
+        {/*    </thead>*/}
+        {/*    <tbody>*/}
+        {/*      {props.table.map((row, index) => {*/}
+        {/*        return (*/}
+        {/*          <tr key={index}>*/}
+        {/*            <th scope="row">{row.label}</th>*/}
+        {/*            <td>{row.value}</td>*/}
+        {/*          </tr>*/}
+        {/*        );*/}
+        {/*      })}*/}
+        {/*    </tbody>*/}
+        {/*  </table>*/}
+        {/*</div>*/}
       </div>
     </>
   );

--- a/packages/design/src/Form/components/TextInput/index.tsx
+++ b/packages/design/src/Form/components/TextInput/index.tsx
@@ -7,6 +7,9 @@ import { type PatternComponent } from '../../../Form/index.js';
 
 const TextInput: PatternComponent<TextInputProps> = props => {
   const { register } = useFormContext();
+  const id = props.idSuffix
+    ? `${props.inputId}${props.idSuffix}`
+    : props.inputId;
   return (
     <div className="usa-form-group-wrapper" key={props.inputId}>
       <div
@@ -18,13 +21,13 @@ const TextInput: PatternComponent<TextInputProps> = props => {
           className={classNames('usa-label', {
             'usa-label--error': props.error,
           })}
-          id={`input-message-${props.inputId}`}
+          id={`input-message-${id}`}
         >
           {props.label}
           {props.error && (
             <span
               className="usa-error-message"
-              id={`input-error-message-${props.inputId}`}
+              id={`input-error-message-${id}`}
               role="alert"
             >
               {props.error.message}
@@ -34,13 +37,13 @@ const TextInput: PatternComponent<TextInputProps> = props => {
             className={classNames('usa-input', {
               'usa-input--error': props.error,
             })}
-            id={`input-${props.inputId}`}
+            id={`input-${id}`}
             defaultValue={props.value}
-            {...register(props.inputId || Math.random().toString(), {
+            {...register(id || Math.random().toString(), {
               //required: props.required,
             })}
             type="text"
-            aria-describedby={`input-message-${props.inputId}`}
+            aria-describedby={`input-message-${id}`}
           />
         </label>
       </div>

--- a/packages/design/src/Form/components/index.tsx
+++ b/packages/design/src/Form/components/index.tsx
@@ -8,6 +8,7 @@ import Page from './Page/index.js';
 import PageSet from './PageSet/index.js';
 import Paragraph from './Paragraph/index.js';
 import RadioGroup from './RadioGroup/index.js';
+import Repeater from './Repeater/index.js';
 import RichText from './RichText/index.js';
 import Sequence from './Sequence/index.js';
 import SubmissionConfirmation from './SubmissionConfirmation/index.js';
@@ -23,6 +24,7 @@ export const defaultPatternComponents: ComponentForPattern = {
   'page-set': PageSet as PatternComponent,
   paragraph: Paragraph as PatternComponent,
   'radio-group': RadioGroup as PatternComponent,
+  repeater: Repeater as PatternComponent,
   'rich-text': RichText as PatternComponent,
   sequence: Sequence as PatternComponent,
   'submission-confirmation': SubmissionConfirmation as PatternComponent,

--- a/packages/design/src/FormManager/FormEdit/AddPatternDropdown.tsx
+++ b/packages/design/src/FormManager/FormEdit/AddPatternDropdown.tsx
@@ -111,9 +111,8 @@ const sidebarPatterns: DropdownPattern[] = [
   ['repeater', defaultFormConfig.patterns['repeater']],
   ['radio-group', defaultFormConfig.patterns['radio-group']],
 ] as const;
-export const compoundFieldChildPatterns: DropdownPattern[] = sidebarPatterns.filter(
-  ([key]) => key !== 'fieldset' && key !== 'repeater'
-);
+export const compoundFieldChildPatterns: DropdownPattern[] =
+  sidebarPatterns.filter(([key]) => key !== 'fieldset' && key !== 'repeater');
 
 export const SidebarAddPatternMenuItem = ({
   patternSelected,

--- a/packages/design/src/FormManager/FormEdit/AddPatternDropdown.tsx
+++ b/packages/design/src/FormManager/FormEdit/AddPatternDropdown.tsx
@@ -1,9 +1,6 @@
 import React, { useState, useRef, useEffect } from 'react';
-
 import { defaultFormConfig, type PatternConfig } from '@atj/forms';
-
 import { useFormManagerStore } from '../store.js';
-
 import styles from './formEditStyles.module.css';
 import blockIcon from './images/block-icon.svg';
 import checkboxIcon from './images/checkbox-icon.svg';
@@ -22,7 +19,7 @@ import classNames from 'classnames';
 const icons: Record<string, string | any> = {
   'block-icon.svg': blockIcon,
   'checkbox-icon.svg': checkboxIcon,
-  'date-icon.svg.svg': dateIcon,
+  'date-icon.svg': dateIcon,
   'dropdown-icon.svg': dropDownIcon,
   'dropdownoption-icon.svg': dropDownOptionIcon,
   'richtext-icon.svg': richTextIcon,
@@ -37,9 +34,14 @@ const getIconPath = (iconPath: string) => {
   return Object.values(icons[iconPath])[0] as string;
 };
 
+interface PatternMenuProps {
+  patternSelected: (patternType: string) => void;
+  title: string;
+}
+
 export const AddPatternMenu = () => {
-  const addPage = useFormManagerStore(state => state.addPage);
-  const { addPattern } = useFormManagerStore(state => ({
+  const { addPage, addPattern } = useFormManagerStore(state => ({
+    addPage: state.addPage,
     addPattern: state.addPattern,
   }));
 
@@ -59,31 +61,45 @@ export const AddPatternMenu = () => {
             />
           </li>
           <li className="tablet:grid-col-12 grid-col-5 text-center">
-            <button
-              className={`${styles.dropdownButton} tablet:width-full text-left width-auto text-base-darkest text-normal padding-0 bg-white border-0 cursor-pointer`}
-              onClick={() => {
-                addPage();
-              }}
-            >
-              <span className="tablet:display-inline-block tablet:width-auto tablet:margin-right-1 display-block width-full text-ttop text-center">
-                <img
-                  className="usa-icon"
-                  src={getIconPath('page-icon.svg')}
-                  alt=""
-                  width="24"
-                  height="24"
-                />
-              </span>
-              <span className="display-inline-block text-ttop tablet:width-auto width-9 text-center">
-                Page
-              </span>
-            </button>
+            <MenuItemButton
+              title="Page"
+              onClick={addPage}
+              iconPath="page-icon.svg"
+            />
           </li>
         </ul>
       </div>
     </fieldset>
   );
 };
+
+const MenuItemButton = ({
+  title,
+  onClick,
+  iconPath,
+}: {
+  title: string;
+  onClick: () => void;
+  iconPath: string;
+}) => (
+  <button
+    className={`${styles.dropdownButton} tablet:width-full text-left width-auto text-base-darkest text-normal padding-0 bg-white border-0 cursor-pointer`}
+    onClick={onClick}
+  >
+    <span className="tablet:display-inline-block tablet:width-auto tablet:margin-right-1 display-block width-full text-ttop text-center">
+      <img
+        className="usa-icon"
+        src={getIconPath(iconPath)}
+        alt=""
+        width="24"
+        height="24"
+      />
+    </span>
+    <span className="display-inline-block text-ttop tablet:width-auto width-9 text-center">
+      {title}
+    </span>
+  </button>
+);
 
 type DropdownPattern = [string, PatternConfig];
 const sidebarPatterns: DropdownPattern[] = [
@@ -92,23 +108,17 @@ const sidebarPatterns: DropdownPattern[] = [
   ['input', defaultFormConfig.patterns['input']],
   ['paragraph', defaultFormConfig.patterns['paragraph']],
   ['rich-text', defaultFormConfig.patterns['rich-text']],
+  ['repeater', defaultFormConfig.patterns['repeater']],
   ['radio-group', defaultFormConfig.patterns['radio-group']],
 ] as const;
-export const fieldsetPatterns: DropdownPattern[] = [
-  ['form-summary', defaultFormConfig.patterns['form-summary']],
-  ['input', defaultFormConfig.patterns['input']],
-  ['paragraph', defaultFormConfig.patterns['paragraph']],
-  ['rich-text', defaultFormConfig.patterns['rich-text']],
-  ['radio-group', defaultFormConfig.patterns['radio-group']],
-] as const;
+export const fieldsetPatterns: DropdownPattern[] = sidebarPatterns.filter(
+  ([key]) => key !== 'fieldset' && key !== 'repeater'
+);
 
 export const SidebarAddPatternMenuItem = ({
   patternSelected,
   title,
-}: {
-  patternSelected: (patternType: string) => void;
-  title: string;
-}) => {
+}: PatternMenuProps) => {
   const [isOpen, setIsOpen] = useState(false);
   const { uswdsRoot } = useFormManagerStore(state => ({
     uswdsRoot: state.context.uswdsRoot,
@@ -137,7 +147,6 @@ export const SidebarAddPatternMenuItem = ({
             <use xlinkHref={`${uswdsRoot}img/sprite.svg#add_circle`}></use>
           </svg>
         </span>
-
         <span className="display-inline-block text-ttop tablet:width-auto text-center">
           <span className="display-inline-block text-ttop margin-right-1 width-9">
             {title}
@@ -155,17 +164,15 @@ export const SidebarAddPatternMenuItem = ({
   );
 };
 
-export const FieldsetAddPatternButton = ({
+export const CompoundAddPatternButton = ({
   patternSelected,
   title,
-}: {
-  patternSelected: (patternType: string) => void;
-  title: string;
-}) => {
+}: PatternMenuProps) => {
   const { uswdsRoot } = useFormManagerStore(state => ({
     uswdsRoot: state.context.uswdsRoot,
   }));
   const [isOpen, setIsOpen] = useState(false);
+
   return (
     <div
       className={classNames(styles.dottedLine, 'margin-top-2 cursor-default')}
@@ -203,13 +210,10 @@ export const FieldsetAddPatternButton = ({
   );
 };
 
-export const FieldsetEmptyStateAddPatternButton = ({
+export const CompoundAddNewPatternButton = ({
   patternSelected,
   title,
-}: {
-  patternSelected: (patternType: string) => void;
-  title: string;
-}) => {
+}: PatternMenuProps) => {
   const [isOpen, setIsOpen] = useState(false);
   return (
     <AddPatternDropdown

--- a/packages/design/src/FormManager/FormEdit/AddPatternDropdown.tsx
+++ b/packages/design/src/FormManager/FormEdit/AddPatternDropdown.tsx
@@ -111,7 +111,7 @@ const sidebarPatterns: DropdownPattern[] = [
   ['repeater', defaultFormConfig.patterns['repeater']],
   ['radio-group', defaultFormConfig.patterns['radio-group']],
 ] as const;
-export const fieldsetPatterns: DropdownPattern[] = sidebarPatterns.filter(
+export const compoundFieldChildPatterns: DropdownPattern[] = sidebarPatterns.filter(
   ([key]) => key !== 'fieldset' && key !== 'repeater'
 );
 
@@ -178,7 +178,7 @@ export const CompoundAddPatternButton = ({
       className={classNames(styles.dottedLine, 'margin-top-2 cursor-default')}
     >
       <AddPatternDropdown
-        availablePatterns={fieldsetPatterns}
+        availablePatterns={compoundFieldChildPatterns}
         closeDropdown={() => setIsOpen(false)}
         isOpen={isOpen}
         patternSelected={patternSelected}
@@ -217,7 +217,7 @@ export const CompoundAddNewPatternButton = ({
   const [isOpen, setIsOpen] = useState(false);
   return (
     <AddPatternDropdown
-      availablePatterns={fieldsetPatterns}
+      availablePatterns={compoundFieldChildPatterns}
       closeDropdown={() => setIsOpen(false)}
       isOpen={isOpen}
       patternSelected={patternSelected}

--- a/packages/design/src/FormManager/FormEdit/components/RepeaterPatternEdit.stories.tsx
+++ b/packages/design/src/FormManager/FormEdit/components/RepeaterPatternEdit.stories.tsx
@@ -1,0 +1,108 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent } from '@storybook/test';
+import { within } from '@testing-library/react';
+
+import { enLocale as message } from '@atj/common';
+import { type RepeaterPattern } from '@atj/forms';
+
+import {
+  createPatternEditStoryMeta,
+  testEmptyFormLabelErrorByElement,
+  testUpdateFormFieldOnSubmitByElement,
+} from './common/story-helper.js';
+import FormEdit from '../index.js';
+
+const pattern: RepeaterPattern = {
+  id: '1',
+  type: 'repeater',
+  data: {
+    legend: 'Repeater pattern description',
+    patterns: [],
+  },
+};
+
+const storyConfig: Meta = {
+  title: 'Edit components/RepeaterPattern',
+  ...createPatternEditStoryMeta({
+    pattern,
+  }),
+} as Meta<typeof FormEdit>;
+export default storyConfig;
+
+export const Basic: StoryObj<typeof FormEdit> = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await testUpdateFormFieldOnSubmitByElement(
+      canvasElement,
+      await canvas.findByText('Repeater pattern description'),
+      'Legend Text Element',
+      'Updated repeater pattern'
+    );
+  },
+};
+
+export const Error: StoryObj<typeof FormEdit> = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await testEmptyFormLabelErrorByElement(
+      canvasElement,
+      await canvas.findByText('Repeater pattern description'),
+      'Legend Text Element',
+      message.patterns.repeater.errorTextMustContainChar
+    );
+  },
+};
+
+export const AddPattern: StoryObj<typeof FormEdit> = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Add a "short answer" question
+    const addQuestionButton = canvas.getByRole('button', {
+      name: /Add question/,
+    });
+    await userEvent.click(addQuestionButton);
+    const shortAnswerButton = canvas.getByRole('button', {
+      name: /Short answer/,
+    });
+    await userEvent.click(shortAnswerButton);
+
+    // Submit new field's edit form
+    const input = await canvas.findByLabelText('Field label');
+    await userEvent.clear(input);
+    await userEvent.type(input, 'Repeater short question');
+    const form = input?.closest('form');
+    form?.requestSubmit();
+
+    // Confirm that the "short answer" field exists
+    const updatedElement = await canvas.findAllByText(
+      'Repeater short question'
+    );
+    await expect(updatedElement.length).toBeGreaterThan(0);
+  },
+};
+
+export const RemovePattern: StoryObj<typeof FormEdit> = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Confirm that the expected repeater legend exists
+    expect(
+      canvas.queryAllByRole('group', {
+        name: /Repeater pattern description/i,
+      })
+    ).toHaveLength(1);
+
+    // Add a "short answer" question
+    const removeSectionButton = canvas.getByRole('button', {
+      name: /Remove section/,
+    });
+    await userEvent.click(removeSectionButton);
+
+    // Confirm that the repeater was removed
+    const test = await canvas.queryAllByRole('group', {
+      name: /Repeater pattern description/i,
+    });
+    expect(test).toHaveLength(0);
+  },
+};

--- a/packages/design/src/FormManager/FormEdit/components/RepeaterPatternEdit.test.tsx
+++ b/packages/design/src/FormManager/FormEdit/components/RepeaterPatternEdit.test.tsx
@@ -1,0 +1,7 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describeStories } from '../../../test-helper.js';
+import meta, * as stories from './RepeaterPatternEdit.stories.js';
+
+describeStories(meta, stories);

--- a/packages/design/src/FormManager/FormEdit/components/RepeaterPatternEdit.tsx
+++ b/packages/design/src/FormManager/FormEdit/components/RepeaterPatternEdit.tsx
@@ -1,15 +1,16 @@
 import classNames from 'classnames';
 import React from 'react';
 
-import { type PatternId, type FieldsetProps } from '@atj/forms';
-import { FieldsetPattern } from '@atj/forms';
+import { type PatternId, type RepeaterProps } from '@atj/forms';
+import { RepeaterPattern } from '@atj/forms';
 
 import {
   CompoundAddPatternButton,
   CompoundAddNewPatternButton,
 } from '../AddPatternDropdown.js';
 import { PatternComponent } from '../../../Form/index.js';
-import Fieldset from '../../../Form/components/Fieldset/index.js';
+import Repeater from '../../../Form/components/Repeater/index.js';
+import RepeaterEditView from '../../../Form/components/Repeater/edit.js';
 import { useFormManagerStore } from '../../store.js';
 import { PatternEditComponent } from '../types.js';
 
@@ -18,7 +19,7 @@ import { PatternEditForm } from './common/PatternEditForm.js';
 import { usePatternEditFormContext } from './common/hooks.js';
 import styles from '../formEditStyles.module.css';
 
-const FieldsetEdit: PatternEditComponent<FieldsetProps> = ({
+const RepeaterEdit: PatternEditComponent<RepeaterProps> = ({
   focus,
   previewProps,
 }) => {
@@ -30,13 +31,13 @@ const FieldsetEdit: PatternEditComponent<FieldsetProps> = ({
           editComponent={<EditComponent patternId={focus.pattern.id} />}
         ></PatternEditForm>
       ) : (
-        <FieldsetPreview {...previewProps} />
+        <RepeaterPreview {...previewProps} />
       )}
     </>
   );
 };
 
-const FieldsetPreview: PatternComponent<FieldsetProps> = props => {
+const RepeaterPreview: PatternComponent<RepeaterProps> = props => {
   const { addPatternToCompoundField, deletePattern } = useFormManagerStore(
     state => ({
       addPatternToCompoundField: state.addPatternToCompoundField,
@@ -48,7 +49,7 @@ const FieldsetPreview: PatternComponent<FieldsetProps> = props => {
   );
   return (
     <>
-      <Fieldset {...(props as FieldsetProps)}>
+      <RepeaterEditView {...(props as RepeaterProps)}>
         {props.children}
         {pattern && pattern.data.patterns.length === 0 && (
           <div
@@ -89,7 +90,7 @@ const FieldsetPreview: PatternComponent<FieldsetProps> = props => {
           >
             <div className={classNames(styles.usaAlertBody, 'usa-alert__body')}>
               <CompoundAddPatternButton
-                title="Add question to fieldset"
+                title="Add question to repeater"
                 patternSelected={patternType =>
                   addPatternToCompoundField(patternType, props._patternId)
                 }
@@ -97,17 +98,17 @@ const FieldsetPreview: PatternComponent<FieldsetProps> = props => {
             </div>
           </div>
         )}
-      </Fieldset>
+      </RepeaterEditView>
     </>
   );
 };
 
 const EditComponent = ({ patternId }: { patternId: PatternId }) => {
-  const pattern = useFormManagerStore<FieldsetPattern>(
+  const pattern = useFormManagerStore<RepeaterPattern>(
     state => state.session.form.patterns[patternId]
   );
   const { fieldId, getFieldState, register } =
-    usePatternEditFormContext<FieldsetPattern>(patternId);
+    usePatternEditFormContext<RepeaterPattern>(patternId);
   const legend = getFieldState('legend');
   return (
     <div className="grid-row">
@@ -141,10 +142,10 @@ const EditComponent = ({ patternId }: { patternId: PatternId }) => {
           autoFocus
         ></input>
       </div>
-      <Fieldset type="fieldset" _patternId={patternId} />
+      <Repeater type="repeater" _patternId={patternId} />
       <PatternEditActions />
     </div>
   );
 };
 
-export default FieldsetEdit;
+export default RepeaterEdit;

--- a/packages/design/src/FormManager/FormEdit/components/common/MovePatternDropdown.tsx
+++ b/packages/design/src/FormManager/FormEdit/components/common/MovePatternDropdown.tsx
@@ -3,7 +3,7 @@ import { useFormManagerStore } from '../../../store.js';
 import styles from '../../formEditStyles.module.css';
 
 interface MovePatternDropdownProps {
-  isFieldset: boolean;
+  isCompound: boolean;
 }
 
 // Define the extended type for pages
@@ -18,7 +18,7 @@ interface PageWithLabel {
 }
 
 const MovePatternDropdown: React.FC<MovePatternDropdownProps> = ({
-  isFieldset,
+  isCompound,
 }) => {
   const context = useFormManagerStore(state => state.context);
   const [dropdownOpen, setDropdownOpen] = useState(false);
@@ -119,7 +119,7 @@ const MovePatternDropdown: React.FC<MovePatternDropdownProps> = ({
           }}
         >
           <span className="display-inline-block text-ttop">
-            {isFieldset ? 'Move fieldset' : 'Move question'}
+            {isCompound ? 'Move questions' : 'Move question'}
           </span>
           <svg
             className="usa-icon display-inline-block text-ttop"
@@ -186,19 +186,19 @@ const MovePatternDropdown: React.FC<MovePatternDropdownProps> = ({
             <button
               type="button"
               aria-label={
-                isFieldset
-                  ? 'Move fieldset to another page'
+                isCompound
+                  ? 'Move these questions to another page'
                   : 'Move question to another page'
               }
               title={
-                isFieldset
-                  ? 'Move fieldset to another page'
+                isCompound
+                  ? 'Move these questions to another page'
                   : 'Move question to another page'
               }
               className="usa-button margin-right-0"
               onClick={handleMovePattern}
             >
-              {isFieldset ? 'Move fieldset' : 'Move question'}
+              {isCompound ? 'Move fieldset' : 'Move question'}
             </button>
           </p>
         </div>

--- a/packages/design/src/FormManager/FormEdit/components/common/PatternEditActions.tsx
+++ b/packages/design/src/FormManager/FormEdit/components/common/PatternEditActions.tsx
@@ -25,10 +25,13 @@ export const PatternEditActions = ({ children }: PatternEditActionsProps) => {
   const isPatternInCompound = useMemo(() => {
     if (!focusPatternId) return false;
     return patterns.some(
-      p => (p.type === 'fieldset' || p.type === 'repeater') && p.data.patterns.includes(focusPatternId)
+      p =>
+        (p.type === 'fieldset' || p.type === 'repeater') &&
+        p.data.patterns.includes(focusPatternId)
     );
   }, [focusPatternId, patterns]);
-  const isCompound = focusPatternType === 'repeater' || focusPatternType === 'fieldset';
+  const isCompound =
+    focusPatternType === 'repeater' || focusPatternType === 'fieldset';
   const isPagePattern = focusPatternType === 'page';
   const { copyPattern } = useFormManagerStore(state => ({
     copyPattern: state.copyPattern,
@@ -36,26 +39,26 @@ export const PatternEditActions = ({ children }: PatternEditActionsProps) => {
   const pages = useFormManagerStore(state =>
     Object.values(state.session.form.patterns).filter(p => p.type === 'page')
   );
-  const fieldsets = useFormManagerStore(state =>
+  const compoundFields = useFormManagerStore(state =>
     Object.values(state.session.form.patterns).filter(
-      p => p.type === 'fieldset'
+      p => p.type === 'fieldset' || p.type === 'repeater'
     )
   );
   const handleCopyPattern = () => {
     const currentPageIndex = pages.findIndex(page =>
       page.data.patterns.includes(focusPatternId || '')
     );
-    const currentFieldsetIndex = fieldsets.findIndex(fieldset =>
-      fieldset.data.patterns.includes(focusPatternId)
+    const compoundFieldIndex = compoundFields.findIndex(compoundField =>
+      compoundField.data.patterns.includes(focusPatternId)
     );
     const sourcePagePatternId = pages[currentPageIndex]?.id;
-    const sourceFieldsetPatternId = fieldsets[currentFieldsetIndex]?.id;
+    const sourceCompoundFieldPatternId = compoundFields[compoundFieldIndex]?.id;
 
     if (focusPatternId) {
       if (sourcePagePatternId) {
         copyPattern(sourcePagePatternId, focusPatternId);
       } else {
-        copyPattern(sourceFieldsetPatternId, focusPatternId);
+        copyPattern(sourceCompoundFieldPatternId, focusPatternId);
       }
     }
   };

--- a/packages/design/src/FormManager/FormEdit/components/common/PatternEditActions.tsx
+++ b/packages/design/src/FormManager/FormEdit/components/common/PatternEditActions.tsx
@@ -22,13 +22,13 @@ export const PatternEditActions = ({ children }: PatternEditActionsProps) => {
     Object.values(state.session.form.patterns)
   );
   const focusPatternId = useFormManagerStore(state => state.focus?.pattern.id);
-  const isPatternInFieldset = useMemo(() => {
+  const isPatternInCompound = useMemo(() => {
     if (!focusPatternId) return false;
     return patterns.some(
-      p => p.type === 'fieldset' && p.data.patterns.includes(focusPatternId)
+      p => (p.type === 'fieldset' || p.type === 'repeater') && p.data.patterns.includes(focusPatternId)
     );
   }, [focusPatternId, patterns]);
-  const isFieldset = focusPatternType === 'fieldset';
+  const isCompound = focusPatternType === 'repeater' || focusPatternType === 'fieldset';
   const isPagePattern = focusPatternType === 'page';
   const { copyPattern } = useFormManagerStore(state => ({
     copyPattern: state.copyPattern,
@@ -74,8 +74,8 @@ export const PatternEditActions = ({ children }: PatternEditActionsProps) => {
           }
         )}
       >
-        {!isPatternInFieldset && !isPagePattern && (
-          <MovePatternDropdown isFieldset={isFieldset} />
+        {!isPatternInCompound && !isPagePattern && (
+          <MovePatternDropdown isCompound={isCompound} />
         )}
         <span
           className={`${styles.patternActionButtons} margin-top-1 margin-bottom-1 display-inline-block text-ttop`}

--- a/packages/design/src/FormManager/FormEdit/components/index.ts
+++ b/packages/design/src/FormManager/FormEdit/components/index.ts
@@ -12,6 +12,7 @@ import PageSetEdit from './PageSetEdit.js';
 import ParagraphPatternEdit from './ParagraphPatternEdit.js';
 import { PatternPreviewSequence } from './PreviewSequencePattern/index.js';
 import RadioGroupPatternEdit from './RadioGroupPatternEdit.js';
+import RepeaterPatternEdit from './RepeaterPatternEdit.js';
 import RichTextPatternEdit from './RichTextPatternEdit/index.js';
 import SubmissionConfirmationEdit from './SubmissionConfirmationEdit.js';
 
@@ -24,6 +25,7 @@ export const defaultPatternEditComponents: EditComponentForPattern = {
   page: PageEdit as PatternEditComponent,
   'page-set': PageSetEdit as PatternEditComponent,
   'radio-group': RadioGroupPatternEdit as PatternEditComponent,
+  repeater: RepeaterPatternEdit as PatternEditComponent,
   'rich-text': RichTextPatternEdit as PatternEditComponent,
   sequence: PatternPreviewSequence as PatternEditComponent,
   'submission-confirmation': SubmissionConfirmationEdit as PatternEditComponent,

--- a/packages/design/src/FormManager/FormEdit/store.ts
+++ b/packages/design/src/FormManager/FormEdit/store.ts
@@ -25,7 +25,10 @@ export type FormEditSlice = {
 
   addPage: () => void;
   addPattern: (patternType: string) => void;
-  addPatternToFieldset: (patternType: string, targetPattern: PatternId) => void;
+  addPatternToCompoundField: (
+    patternType: string,
+    targetPattern: PatternId
+  ) => void;
   clearFocus: () => void;
   copyPattern: (parentPatternId: PatternId, patternId: PatternId) => void;
   deletePattern: (id: PatternId) => void;
@@ -118,25 +121,30 @@ export const createFormEditSlice =
       });
       state.addNotification('success', 'Element copied successfully.');
     },
-
-    addPatternToFieldset: (patternType, targetPattern) => {
+    addPatternToCompoundField: (patternType, targetPattern) => {
       const state = get();
       const builder = new BlueprintBuilder(
         state.context.config,
         state.session.form
       );
-      const newPattern = builder.addPatternToFieldset(
-        patternType,
-        targetPattern
-      );
-      set({
-        session: mergeSession(state.session, { form: builder.form }),
-        focus: { pattern: newPattern },
-      });
-      state.addNotification(
-        'success',
-        'Element added to fieldset successfully.'
-      );
+      const targetPatternType = builder.getPatternTypeById(targetPattern);
+      if (['fieldset', 'repeater'].includes(targetPatternType)) {
+        let newPattern: Pattern;
+        if (targetPatternType === 'fieldset') {
+          newPattern = builder.addPatternToFieldset(patternType, targetPattern);
+        } else {
+          newPattern = builder.addPatternToRepeater(patternType, targetPattern);
+        }
+
+        set({
+          session: mergeSession(state.session, { form: builder.form }),
+          focus: { pattern: newPattern },
+        });
+        state.addNotification(
+          'success',
+          `Element added to ${targetPatternType} successfully.`
+        );
+      }
     },
     clearFocus: () => {
       set({ focus: undefined });

--- a/packages/forms/src/builder/index.ts
+++ b/packages/forms/src/builder/index.ts
@@ -10,6 +10,7 @@ import {
   addDocument,
   addPageToPageSet,
   addPatternToFieldset,
+  addPatternToRepeater,
   addPatternToPage,
   copyPattern,
   createDefaultPattern,
@@ -101,6 +102,11 @@ export class BlueprintBuilder {
     return results.pattern;
   }
 
+  getPatternTypeById(patternId: PatternId) {
+    const root = this.form.patterns[patternId];
+    return root.type;
+  }
+
   addPatternToFieldset(patternType: string, fieldsetPatternId: PatternId) {
     const pattern = createDefaultPattern(this.config, patternType);
     const root = this.form.patterns[fieldsetPatternId] as FieldsetPattern;
@@ -108,6 +114,16 @@ export class BlueprintBuilder {
       throw new Error('expected pattern to be a fieldset');
     }
     this.bp = addPatternToFieldset(this.form, fieldsetPatternId, pattern);
+    return pattern;
+  }
+
+  addPatternToRepeater(patternType: string, fieldsetPatternId: PatternId) {
+    const pattern = createDefaultPattern(this.config, patternType);
+    const root = this.form.patterns[fieldsetPatternId] as FieldsetPattern;
+    if (root.type !== 'repeater') {
+      throw new Error('expected pattern to be a repeater');
+    }
+    this.bp = addPatternToRepeater(this.form, fieldsetPatternId, pattern);
     return pattern;
   }
 

--- a/packages/forms/src/builder/index.ts
+++ b/packages/forms/src/builder/index.ts
@@ -23,6 +23,7 @@ import {
 } from '../index.js';
 import { type PageSetPattern } from '../patterns/page-set/config.js';
 import { type FieldsetPattern } from '../patterns/fieldset/index.js';
+import { type RepeaterPattern } from '../patterns/repeater/index.js';
 
 export class BlueprintBuilder {
   bp: Blueprint;
@@ -117,13 +118,13 @@ export class BlueprintBuilder {
     return pattern;
   }
 
-  addPatternToRepeater(patternType: string, fieldsetPatternId: PatternId) {
+  addPatternToRepeater(patternType: string, patternId: PatternId) {
     const pattern = createDefaultPattern(this.config, patternType);
-    const root = this.form.patterns[fieldsetPatternId] as FieldsetPattern;
+    const root = this.form.patterns[patternId] as RepeaterPattern;
     if (root.type !== 'repeater') {
       throw new Error('expected pattern to be a repeater');
     }
-    this.bp = addPatternToRepeater(this.form, fieldsetPatternId, pattern);
+    this.bp = addPatternToRepeater(this.form, patternId, pattern);
     return pattern;
   }
 

--- a/packages/forms/src/components.ts
+++ b/packages/forms/src/components.ts
@@ -10,6 +10,7 @@ import { type FormSession, nullSession, sessionIsComplete } from './session.js';
 export type TextInputProps = PatternProps<{
   type: 'input';
   inputId: string;
+  idSuffix?: string;
   value: string;
   label: string;
   required: boolean;
@@ -54,6 +55,7 @@ export type ZipcodeProps = PatternProps<{
 export type CheckboxProps = PatternProps<{
   type: 'checkbox';
   id: string;
+  idSuffix?: string;
   label: string;
   defaultChecked: boolean;
 }>;
@@ -73,12 +75,21 @@ export type RadioGroupProps = PatternProps<{
   type: 'radio-group';
   groupId: string;
   legend: string;
+  idSuffix?: string;
   options: {
     id: string;
     name: string;
     label: string;
     defaultChecked: boolean;
   }[];
+}>;
+
+export type RepeaterProps = PatternProps<{
+  type: 'repeater';
+  legend?: string;
+  showControls?: boolean;
+  subHeading?: string;
+  error?: FormError;
 }>;
 
 export type SequenceProps = PatternProps<{

--- a/packages/forms/src/documents/document.ts
+++ b/packages/forms/src/documents/document.ts
@@ -135,7 +135,11 @@ export const addDocumentFieldsToForm = (
           maxLength: 128,
         },
       } satisfies InputPattern);
-    } else if (field.type === 'Paragraph' || field.type === 'RichText') {
+    } else if (
+      field.type === 'Paragraph' ||
+      field.type === 'RichText' ||
+      field.type === 'Repeater'
+    ) {
       // skip purely presentational fields
     } else if (field.type === 'not-supported') {
       console.error(`Skipping field: ${field.error}`);

--- a/packages/forms/src/documents/pdf/generate.ts
+++ b/packages/forms/src/documents/pdf/generate.ts
@@ -129,7 +129,11 @@ const setFormFieldData = (
         field.uncheck();
       }
     }
-  } else if (fieldType === 'Paragraph' || fieldType === 'RichText') {
+  } else if (
+    fieldType === 'Paragraph' ||
+    fieldType === 'RichText' ||
+    fieldType === 'Repeater'
+  ) {
     // do nothing
   } else {
     const exhaustiveCheck: never = fieldType;

--- a/packages/forms/src/documents/pdf/index.ts
+++ b/packages/forms/src/documents/pdf/index.ts
@@ -19,4 +19,5 @@ export type PDFFieldType =
   | 'OptionList'
   | 'RadioGroup'
   | 'Paragraph'
+  | 'Repeater'
   | 'RichText';

--- a/packages/forms/src/documents/types.ts
+++ b/packages/forms/src/documents/types.ts
@@ -45,6 +45,14 @@ export type DocumentFieldValue =
       required: boolean;
     }
   | {
+      type: 'Repeater';
+      name: string;
+      options: string[];
+      label: string;
+      value: string;
+      required: boolean;
+    }
+  | {
       type: 'RichText';
       name: string;
       options: string[];

--- a/packages/forms/src/index.ts
+++ b/packages/forms/src/index.ts
@@ -519,12 +519,12 @@ export const addPatternToFieldset = (
 
 export const addPatternToRepeater = (
   bp: Blueprint,
-  fieldsetPatternId: PatternId,
+  repeaterPatternId: PatternId,
   pattern: Pattern,
   index?: number
 ): Blueprint => {
-  const fieldsetPattern = bp.patterns[fieldsetPatternId] as FieldsetPattern;
-  if (fieldsetPattern.type !== 'repeater') {
+  const repeaterPattern = bp.patterns[repeaterPatternId] as RepeaterPattern;
+  if (repeaterPattern.type !== 'repeater') {
     throw new Error('Pattern is not a repeater.');
   }
 
@@ -532,25 +532,25 @@ export const addPatternToRepeater = (
 
   if (index !== undefined) {
     updatedPagePattern = [
-      ...fieldsetPattern.data.patterns.slice(0, index + 1),
+      ...repeaterPattern.data.patterns.slice(0, index + 1),
       pattern.id,
-      ...fieldsetPattern.data.patterns.slice(index + 1),
+      ...repeaterPattern.data.patterns.slice(index + 1),
     ];
   } else {
-    updatedPagePattern = [...fieldsetPattern.data.patterns, pattern.id];
+    updatedPagePattern = [...repeaterPattern.data.patterns, pattern.id];
   }
 
   return {
     ...bp,
     patterns: {
       ...bp.patterns,
-      [fieldsetPattern.id]: {
-        ...fieldsetPattern,
+      [repeaterPattern.id]: {
+        ...repeaterPattern,
         data: {
-          ...fieldsetPattern.data,
+          ...repeaterPattern.data,
           patterns: updatedPagePattern,
         },
-      } satisfies FieldsetPattern,
+      } satisfies RepeaterPattern,
       [pattern.id]: pattern,
     },
   };

--- a/packages/forms/src/index.ts
+++ b/packages/forms/src/index.ts
@@ -485,18 +485,21 @@ export const addPatternToCompoundField = (
   type: 'fieldset' | 'repeater',
   index?: number
 ): Blueprint => {
-  const targetPattern = bp.patterns[patternId] as FieldsetPattern | RepeaterPattern;
+  const targetPattern = bp.patterns[patternId] as
+    | FieldsetPattern
+    | RepeaterPattern;
   if (targetPattern.type !== type) {
     throw new Error(`Pattern is not a ${type}.`);
   }
 
-  const updatedPatterns = index !== undefined
-    ? [
-      ...targetPattern.data.patterns.slice(0, index + 1),
-      pattern.id,
-      ...targetPattern.data.patterns.slice(index + 1),
-    ]
-    : [...targetPattern.data.patterns, pattern.id];
+  const updatedPatterns =
+    index !== undefined
+      ? [
+          ...targetPattern.data.patterns.slice(0, index + 1),
+          pattern.id,
+          ...targetPattern.data.patterns.slice(index + 1),
+        ]
+      : [...targetPattern.data.patterns, pattern.id];
 
   return {
     ...bp,
@@ -520,7 +523,13 @@ export const addPatternToFieldset = (
   pattern: Pattern,
   index?: number
 ): Blueprint => {
-  return addPatternToCompoundField(bp, fieldsetPatternId, pattern, 'fieldset', index);
+  return addPatternToCompoundField(
+    bp,
+    fieldsetPatternId,
+    pattern,
+    'fieldset',
+    index
+  );
 };
 
 export const addPatternToRepeater = (
@@ -529,7 +538,13 @@ export const addPatternToRepeater = (
   pattern: Pattern,
   index?: number
 ): Blueprint => {
-  return addPatternToCompoundField(bp, repeaterPatternId, pattern, 'repeater', index);
+  return addPatternToCompoundField(
+    bp,
+    repeaterPatternId,
+    pattern,
+    'repeater',
+    index
+  );
 };
 
 export const addPageToPageSet = (

--- a/packages/forms/src/index.ts
+++ b/packages/forms/src/index.ts
@@ -478,43 +478,49 @@ export const copyPattern = (
   return { bp: updatedBp, pattern: newPattern };
 };
 
+export const addPatternToCompoundField = (
+  bp: Blueprint,
+  patternId: PatternId,
+  pattern: Pattern,
+  type: 'fieldset' | 'repeater',
+  index?: number
+): Blueprint => {
+  const targetPattern = bp.patterns[patternId] as FieldsetPattern | RepeaterPattern;
+  if (targetPattern.type !== type) {
+    throw new Error(`Pattern is not a ${type}.`);
+  }
+
+  const updatedPatterns = index !== undefined
+    ? [
+      ...targetPattern.data.patterns.slice(0, index + 1),
+      pattern.id,
+      ...targetPattern.data.patterns.slice(index + 1),
+    ]
+    : [...targetPattern.data.patterns, pattern.id];
+
+  return {
+    ...bp,
+    patterns: {
+      ...bp.patterns,
+      [targetPattern.id]: {
+        ...targetPattern,
+        data: {
+          ...targetPattern.data,
+          patterns: updatedPatterns,
+        },
+      } satisfies FieldsetPattern | RepeaterPattern,
+      [pattern.id]: pattern,
+    },
+  };
+};
+
 export const addPatternToFieldset = (
   bp: Blueprint,
   fieldsetPatternId: PatternId,
   pattern: Pattern,
   index?: number
 ): Blueprint => {
-  const fieldsetPattern = bp.patterns[fieldsetPatternId] as FieldsetPattern;
-  if (fieldsetPattern.type !== 'fieldset') {
-    throw new Error('Pattern is not a page.');
-  }
-
-  let updatedPagePattern: PatternId[];
-
-  if (index !== undefined) {
-    updatedPagePattern = [
-      ...fieldsetPattern.data.patterns.slice(0, index + 1),
-      pattern.id,
-      ...fieldsetPattern.data.patterns.slice(index + 1),
-    ];
-  } else {
-    updatedPagePattern = [...fieldsetPattern.data.patterns, pattern.id];
-  }
-
-  return {
-    ...bp,
-    patterns: {
-      ...bp.patterns,
-      [fieldsetPattern.id]: {
-        ...fieldsetPattern,
-        data: {
-          ...fieldsetPattern.data,
-          patterns: updatedPagePattern,
-        },
-      } satisfies FieldsetPattern,
-      [pattern.id]: pattern,
-    },
-  };
+  return addPatternToCompoundField(bp, fieldsetPatternId, pattern, 'fieldset', index);
 };
 
 export const addPatternToRepeater = (
@@ -523,37 +529,7 @@ export const addPatternToRepeater = (
   pattern: Pattern,
   index?: number
 ): Blueprint => {
-  const repeaterPattern = bp.patterns[repeaterPatternId] as RepeaterPattern;
-  if (repeaterPattern.type !== 'repeater') {
-    throw new Error('Pattern is not a repeater.');
-  }
-
-  let updatedPagePattern: PatternId[];
-
-  if (index !== undefined) {
-    updatedPagePattern = [
-      ...repeaterPattern.data.patterns.slice(0, index + 1),
-      pattern.id,
-      ...repeaterPattern.data.patterns.slice(index + 1),
-    ];
-  } else {
-    updatedPagePattern = [...repeaterPattern.data.patterns, pattern.id];
-  }
-
-  return {
-    ...bp,
-    patterns: {
-      ...bp.patterns,
-      [repeaterPattern.id]: {
-        ...repeaterPattern,
-        data: {
-          ...repeaterPattern.data,
-          patterns: updatedPagePattern,
-        },
-      } satisfies RepeaterPattern,
-      [pattern.id]: pattern,
-    },
-  };
+  return addPatternToCompoundField(bp, repeaterPatternId, pattern, 'repeater', index);
 };
 
 export const addPageToPageSet = (

--- a/packages/forms/src/index.ts
+++ b/packages/forms/src/index.ts
@@ -24,6 +24,7 @@ import { type PageSetPattern } from './patterns/page-set/config.js';
 export { type RichTextPattern } from './patterns/rich-text.js';
 import { type SequencePattern } from './patterns/sequence.js';
 import { FieldsetPattern } from './patterns/index.js';
+import { RepeaterPattern } from './patterns/index.js';
 export {
   type FormRepository,
   createFormsRepository,
@@ -486,6 +487,45 @@ export const addPatternToFieldset = (
   const fieldsetPattern = bp.patterns[fieldsetPatternId] as FieldsetPattern;
   if (fieldsetPattern.type !== 'fieldset') {
     throw new Error('Pattern is not a page.');
+  }
+
+  let updatedPagePattern: PatternId[];
+
+  if (index !== undefined) {
+    updatedPagePattern = [
+      ...fieldsetPattern.data.patterns.slice(0, index + 1),
+      pattern.id,
+      ...fieldsetPattern.data.patterns.slice(index + 1),
+    ];
+  } else {
+    updatedPagePattern = [...fieldsetPattern.data.patterns, pattern.id];
+  }
+
+  return {
+    ...bp,
+    patterns: {
+      ...bp.patterns,
+      [fieldsetPattern.id]: {
+        ...fieldsetPattern,
+        data: {
+          ...fieldsetPattern.data,
+          patterns: updatedPagePattern,
+        },
+      } satisfies FieldsetPattern,
+      [pattern.id]: pattern,
+    },
+  };
+};
+
+export const addPatternToRepeater = (
+  bp: Blueprint,
+  fieldsetPatternId: PatternId,
+  pattern: Pattern,
+  index?: number
+): Blueprint => {
+  const fieldsetPattern = bp.patterns[fieldsetPatternId] as FieldsetPattern;
+  if (fieldsetPattern.type !== 'repeater') {
+    throw new Error('Pattern is not a repeater.');
   }
 
   let updatedPagePattern: PatternId[];

--- a/packages/forms/src/patterns/index.ts
+++ b/packages/forms/src/patterns/index.ts
@@ -3,6 +3,7 @@ import { type FormConfig } from '../pattern.js';
 import { addressConfig } from './address/index.js';
 import { checkboxConfig } from './checkbox.js';
 import { fieldsetConfig } from './fieldset/index.js';
+import { repeaterConfig } from './repeater/index.js';
 import { formSummaryConfig } from './form-summary.js';
 import { inputConfig } from './input/index.js';
 import { pageConfig } from './page/index.js';
@@ -25,6 +26,7 @@ export const defaultFormConfig: FormConfig = {
     page: pageConfig,
     'page-set': pageSetConfig,
     paragraph: paragraphConfig,
+    repeater: repeaterConfig,
     'rich-text': richTextConfig,
     'radio-group': radioGroupConfig,
     sequence: sequenceConfig,
@@ -42,4 +44,5 @@ export * from './checkbox.js';
 export * from './form-summary.js';
 export * from './paragraph.js';
 export * from './radio-group.js';
+export * from './repeater/index.js';
 export * from './sequence.js';

--- a/packages/forms/src/patterns/input/response.ts
+++ b/packages/forms/src/patterns/input/response.ts
@@ -6,11 +6,19 @@ import { safeZodParseToFormError } from '../../util/zod.js';
 import { type InputPattern } from './index.js';
 
 const createSchema = (data: InputPattern['data']) => {
-  const schema = z.string().max(data.maxLength);
-  if (!data.required) {
-    return schema;
-  }
-  return schema.min(1, { message: 'This field is required' });
+  const stringSchema = z.string().max(data.maxLength);
+
+  const baseSchema = data.required
+    ? stringSchema.min(1, { message: 'This field is required' })
+    : stringSchema;
+
+  // Using z.union to handle both single string and object with `repeater` array of strings
+  return z.union([
+    baseSchema,
+    z.object({
+      repeater: z.array(baseSchema),
+    }),
+  ]);
 };
 
 export type InputPatternOutput = z.infer<ReturnType<typeof createSchema>>;

--- a/packages/forms/src/patterns/repeater/config.ts
+++ b/packages/forms/src/patterns/repeater/config.ts
@@ -1,0 +1,31 @@
+import { z } from 'zod';
+
+import { safeZodParseFormErrors } from '../../util/zod.js';
+import { ParsePatternConfigData } from '../../pattern.js';
+
+const configSchema = z.object({
+  legend: z.string().min(1),
+  patterns: z.union([
+    // Support either an array of strings...
+    z.array(z.string()),
+    // ...or a comma-separated string.
+    // REVISIT: This is messy, and exists only so we can store the data easily
+    // as a hidden input in the form. We should probably just store it as JSON.
+    z
+      .string()
+      .transform(value =>
+        value
+          .split(',')
+          .map(String)
+          .filter(value => value)
+      )
+      .pipe(z.string().array()),
+  ]),
+});
+export type RepeaterConfigSchema = z.infer<typeof configSchema>;
+
+export const parseConfigData: ParsePatternConfigData<
+  RepeaterConfigSchema
+> = obj => {
+  return safeZodParseFormErrors(configSchema, obj);
+};

--- a/packages/forms/src/patterns/repeater/index.ts
+++ b/packages/forms/src/patterns/repeater/index.ts
@@ -1,0 +1,44 @@
+import {
+  type Pattern,
+  type PatternConfig,
+  type PatternId,
+} from '../../pattern.js';
+import { parseConfigData } from './config.js';
+import { createPrompt } from './prompt.js';
+
+export type RepeaterPattern = Pattern<{
+  legend?: string;
+  showControls?: boolean;
+  patterns: PatternId[];
+}>;
+
+export const repeaterConfig: PatternConfig<RepeaterPattern> = {
+  displayName: 'Repeater',
+  iconPath: 'block-icon.svg',
+  initial: {
+    legend: 'Default Heading',
+    patterns: [],
+  },
+  parseConfigData,
+  getChildren(pattern, patterns) {
+    return pattern.data.patterns.map(
+      (patternId: string) => patterns[patternId]
+    );
+  },
+  removeChildPattern(pattern, patternId) {
+    const newPatterns = pattern.data.patterns.filter(
+      (id: string) => patternId !== id
+    );
+    if (newPatterns.length === pattern.data.patterns.length) {
+      return pattern;
+    }
+    return {
+      ...pattern,
+      data: {
+        ...pattern.data,
+        patterns: newPatterns,
+      },
+    };
+  },
+  createPrompt,
+};

--- a/packages/forms/src/patterns/repeater/prompt.ts
+++ b/packages/forms/src/patterns/repeater/prompt.ts
@@ -1,0 +1,28 @@
+import { type RepeaterPattern } from './index.js';
+import {
+  type CreatePrompt,
+  type RepeaterProps,
+  createPromptForPattern,
+  getPattern,
+} from '../../index.js';
+
+export const createPrompt: CreatePrompt<RepeaterPattern> = (
+  config,
+  session,
+  pattern,
+  options
+) => {
+  const children = pattern.data.patterns.map((patternId: string) => {
+    const childPattern = getPattern(session.form, patternId);
+    return createPromptForPattern(config, session, childPattern, options);
+  });
+  return {
+    props: {
+      _patternId: pattern.id,
+      type: 'repeater',
+      legend: pattern.data.legend,
+      showControls: true,
+    } satisfies RepeaterProps,
+    children,
+  };
+};

--- a/packages/forms/src/response.ts
+++ b/packages/forms/src/response.ts
@@ -39,8 +39,7 @@ const parsePromptResponse = (
   const values: Record<string, any> = {};
   const errors: FormErrorMap = {};
   for (const [patternId, promptValue] of Object.entries(response.data)) {
-    const id = getPatternId(patternId);
-    const pattern = getPattern(session.form, id);
+    const pattern = getPattern(session.form, patternId);
     const patternConfig = getPatternConfig(config, pattern.type);
     const isValidResult = validatePattern(patternConfig, pattern, promptValue);
     if (isValidResult.success) {
@@ -50,8 +49,4 @@ const parsePromptResponse = (
     }
   }
   return { errors, values };
-};
-
-const getPatternId = (id: string) => {
-  return id.replace(/_repeater_(\d+)$/, '');
 };

--- a/packages/forms/src/response.ts
+++ b/packages/forms/src/response.ts
@@ -39,7 +39,8 @@ const parsePromptResponse = (
   const values: Record<string, any> = {};
   const errors: FormErrorMap = {};
   for (const [patternId, promptValue] of Object.entries(response.data)) {
-    const pattern = getPattern(session.form, patternId);
+    const id = getPatternId(patternId);
+    const pattern = getPattern(session.form, id);
     const patternConfig = getPatternConfig(config, pattern.type);
     const isValidResult = validatePattern(patternConfig, pattern, promptValue);
     if (isValidResult.success) {
@@ -49,4 +50,8 @@ const parsePromptResponse = (
     }
   }
   return { errors, values };
+};
+
+const getPatternId = (id: string) => {
+  return id.replace(/_repeater_(\d+)$/, '');
 };


### PR DESCRIPTION
Added the repeater pattern with basic support for the available question types at the start of the sprint (short answer and radio group). 

There is a bug in the form submission side where the thank you page flashes briefly, and then re-renders the form fields with the user input, so the summary table on the results page was turned off for now.